### PR TITLE
修正检查lua函数调用的一个错误：当多返回值的函数调用结果作为另外一个函数调用的实参时，会错误的发出警告

### DIFF
--- a/src/test/kotlin/com/tang/intellij/test/inspections/MatchFunctionSignatureTest.kt
+++ b/src/test/kotlin/com/tang/intellij/test/inspections/MatchFunctionSignatureTest.kt
@@ -42,4 +42,20 @@ class MatchFunctionSignatureTest : LuaInspectionsTestBase(MatchFunctionSignature
         end
         test(1<warning>)</warning>
     """)
+    fun testMultiReturn() = checkByText("""
+        local function ret_nn()
+            return 1, 2
+        end
+        local function ret_sn()
+            return "1", 2
+        end
+        ---@param n1 number
+        ---@param n2 number
+        local function acp_nn(n1, n2) end
+
+        acp_nn(ret_nn())
+        acp_nn(<warning>ret_sn()</warning>)
+        acp_nn(ret_nn(), 1)
+        acp_nn(<warning>ret_sn()</warning>, 1)
+    """)
 }


### PR DESCRIPTION
> 若将函数作为表达式的一部分来调用时，Lua只保留函数的第一个返回值。只有当一个函数调用时一系列表达式中的最后一个元素时，才返回所有返回值。