### PR TITLE
修复可能存在的乱码问题

### DIFF
--- a/debugger/attach/windows/src/emmy.backend/StdRedirector.cpp
+++ b/debugger/attach/windows/src/emmy.backend/StdRedirector.cpp
@@ -14,7 +14,7 @@ void StdRedirector::redirect(const std::function<void(const char*, int)>& handle
 	saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
 	saAttr.bInheritHandle = TRUE;
 	saAttr.lpSecurityDescriptor = nullptr;
-	bool s = CreatePipe(&m_hChildStd_Rd, &m_hChildStd_Wr, &saAttr, 0);
+	BOOL s = CreatePipe(&m_hChildStd_Rd, &m_hChildStd_Wr, &saAttr, 0);
 	old = _dup(m_target);
 	if (old == -1)
 	{
@@ -26,21 +26,76 @@ void StdRedirector::redirect(const std::function<void(const char*, int)>& handle
 		test = _fdopen(stream, "wt");
 
 	// stdout now refers to file "test" 
-	if (_dup2(_fileno(test), m_target) == -1)
+	if (_dup2(/*_fileno(test)*/stream, m_target) == -1)
 	{
 		perror("Can't _dup2 stdout");
 		return;
 	}
+	// no buffer
 	setvbuf(stdout, nullptr, _IONBF, 0);
 	std::thread thread([this, handler]()
 	{
-		char buf[1024] = { 0 };
+		const int BUFF_SIZE = 1024;
+		const int MAX_BUFF_SIZE = BUFF_SIZE + 5;
+		char buf[MAX_BUFF_SIZE] = { 0 };
+		char lastChars[5] = { 0 };
+		int lastCharsLength = 0;
 		while (true) {
 			DWORD w;
-			ZeroMemory(buf, 1024);
-			const bool suc = ReadFile(m_hChildStd_Rd, buf, 1024, &w, nullptr);
+			ZeroMemory(buf, MAX_BUFF_SIZE);
+			char* pBuff = buf;
+			if (lastCharsLength > 0) {
+				pBuff = &buf[lastCharsLength];
+				// copy the last half chars to buff
+				memcpy(buf, lastChars, lastCharsLength);
+			}
+			const BOOL suc = ReadFile(m_hChildStd_Rd, pBuff, BUFF_SIZE, &w, nullptr);
 			if (suc && w > 0) {
-				handler(buf, w);
+				// process utf8 char array
+				int i = 0;
+				int charLength = 0;
+				
+				int buffRealLength = w + lastCharsLength;
+
+				while (true) {
+					unsigned char c = (unsigned)buf[i];
+
+					if (c >= 0xFC) {
+						charLength = 6;
+					} else if (c >= 0xF8) {
+						charLength = 5;
+					} else if (c >= 0xF0) {
+						charLength = 4;
+					} else if (c >= 0xE0) {
+						charLength = 3;
+					} else if (c >= 0xC8) {
+						charLength = 2;
+					} else {
+						charLength = 1;
+					}
+
+					if (i + charLength > buffRealLength) {
+						break;
+					} else {
+						i += charLength;
+						// the last char has been processed, break.
+						if (i == buffRealLength) {
+							break;
+						}
+					}
+				}
+
+				// store the last char to cache for next read-buff to combine
+				ZeroMemory(lastChars, sizeof(lastChars) / sizeof(lastChars[0]));
+				lastCharsLength = 0;
+				for (int j = i; j < buffRealLength; j++) {
+					lastChars[j - i] = buf[j];
+					// mark string end
+					buf[j] = 0;
+					lastCharsLength++;
+				}
+
+				handler(buf, buffRealLength);
 			}
 		}
 	});


### PR DESCRIPTION
lua的console中的内容是UTF8编码的，StdRedirector从管道中使用buff读取被重定向的console会存在读取了半个字符的情况，此时idea的控制台会乱码，因此需要对从管道中读取的buff做字符完整性校验，保证返回给Idea的Console的是完整的字符数组。