### PR TITLE
Unity Attach Debugger support

### DIFF
--- a/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachDebugger.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachDebugger.kt
@@ -24,6 +24,8 @@ import com.intellij.xdebugger.XDebugProcessStarter
 import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.attach.XLocalAttachDebugger
+import com.tang.intellij.lua.debugger.utils.ProcessDetailInfo
+import com.tang.intellij.lua.debugger.utils.getDisplayName
 
 /**
  *

--- a/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachDebuggerProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachDebuggerProvider.kt
@@ -16,33 +16,16 @@
 
 package com.tang.intellij.lua.debugger.attach
 
-import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessInfo
-import com.intellij.execution.util.ExecUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.UserDataHolder
 import com.intellij.xdebugger.attach.XLocalAttachDebugger
 import com.intellij.xdebugger.attach.XLocalAttachDebuggerProvider
 import com.intellij.xdebugger.attach.XLocalAttachGroup
-import com.tang.intellij.lua.psi.LuaFileUtil
-import java.io.ByteArrayInputStream
+import com.tang.intellij.lua.debugger.utils.ProcessDetailInfo
+import com.tang.intellij.lua.debugger.utils.ProcessUtils
 import java.util.*
-import javax.xml.parsers.DocumentBuilderFactory
-
-data class ProcessDetailInfo(var pid: Int = 0, var path: String = "", var title: String = "")
-
-private const val MAX_DISPLAY_LEN = 60
-
-internal fun getDisplayName(processInfo: ProcessInfo, detailInfo: ProcessDetailInfo): String {
-    val s = if (detailInfo.title.isNotEmpty())
-        "${processInfo.executableName} - ${detailInfo.title}"
-    else processInfo.executableName
-
-    if (s.length > MAX_DISPLAY_LEN)
-        return "${s.substring(0, MAX_DISPLAY_LEN)}..."
-    return s
-}
 
 /**
  *
@@ -53,57 +36,16 @@ class LuaLocalAttachDebuggerProvider : XLocalAttachDebuggerProvider {
     override fun getAttachGroup(): XLocalAttachGroup = LuaLocalAttachGroup.INSTANCE
 
     companion object {
-        val DETAIL_KEY = Key.create<MutableMap<Int, ProcessDetailInfo>>("LuaLocalAttachDebuggerProvider.key")
+        val DETAIL_KEY = Key.create<Map<Int, ProcessDetailInfo>>("LuaLocalAttachDebuggerProvider.key")
     }
 
-    private val processMap = mutableMapOf<Int, ProcessDetailInfo>()
-
-    private fun listProcesses() {
-        processMap.clear()
-        val archExe = LuaFileUtil.getArchExeFile()
-        val commandLine = GeneralCommandLine(archExe)
-        //commandLine.charset = Charset.forName("UTF-8")
-        commandLine.addParameters("list_processes")
-
-        val processOutput = ExecUtil.execAndGetOutput(commandLine)
-
-        val text = processOutput.stdout
-        val builder = DocumentBuilderFactory.newInstance()
-        val documentBuilder = builder.newDocumentBuilder()
-        val document = documentBuilder.parse(ByteArrayInputStream(text.toByteArray()))
-        val root = document.documentElement
-        root.childNodes.let {
-            for (i in 0 until it.length) {
-                val c = it.item(i)
-                val p = ProcessDetailInfo()
-                val map = c.attributes
-                map.getNamedItem("pid")?.let {
-                    p.pid = it.nodeValue.toInt()
-                }
-                val childNodes = c.childNodes
-                for (j in 0 until childNodes.length) {
-                    val child = childNodes.item(j)
-                    when (child.nodeName) {
-                        "title" -> {
-                            val item = child.childNodes.item(0)
-                            p.title = item?.nodeValue ?: ""
-                        }
-                        "path" -> {
-                            val item = child.childNodes.item(0)
-                            p.path = item?.nodeValue ?: ""
-                        }
-                    }
-                }
-                processMap[p.pid] = p
-            }
-        }
-    }
+    private var processMap = mapOf<Int, ProcessDetailInfo>()
 
     override fun getAvailableDebuggers(project: Project, processInfo: ProcessInfo, userDataHolder: UserDataHolder): List<XLocalAttachDebugger> {
 
         val b = userDataHolder.getUserData(DETAIL_KEY)
         if (b == null) {
-            listProcesses()
+            processMap = ProcessUtils.listProcesses()
             userDataHolder.putUserData(DETAIL_KEY, processMap)
         }
 

--- a/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachGroup.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachGroup.kt
@@ -20,6 +20,7 @@ import com.intellij.execution.process.ProcessInfo
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.UserDataHolder
 import com.intellij.xdebugger.attach.XLocalAttachGroup
+import com.tang.intellij.lua.debugger.utils.getDisplayName
 import com.tang.intellij.lua.lang.LuaIcons
 import com.tang.intellij.lua.lang.LuaLanguage
 import sun.awt.shell.ShellFolder

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfiguration.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfiguration.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.remote
+
+import com.intellij.execution.ExecutionException
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.configurations.RunProfileState
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.options.SettingsEditorGroup
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.InvalidDataException
+import com.intellij.openapi.util.JDOMExternalizerUtil
+import com.intellij.openapi.util.WriteExternalException
+import com.tang.intellij.lua.debugger.LuaCommandLineState
+import com.tang.intellij.lua.debugger.LuaRunConfiguration
+import com.tang.intellij.lua.debugger.unity.LuaUnitySettingsEditor
+import org.jdom.Element
+
+/**
+ *
+ * Created by Taigacon on 2018/11/6.
+ */
+class LuaUnityConfiguration(project: Project, factory: ConfigurationFactory)
+    : LuaRunConfiguration(project, factory), RunConfigurationWithSuppressedDefaultRunAction {
+
+    var preferedUnityInstanceName: String = ""
+
+    override fun checkConfiguration() {
+        super.checkConfiguration()
+        checkSourceRoot()
+    }
+
+    override fun getValidModules(): Collection<Module> {
+        //final Module[] modules = ModuleManager.getInstance(getProject()).getModules();
+        return emptyList()
+    }
+
+    override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
+        val group = SettingsEditorGroup<LuaUnityConfiguration>()
+        group.addEditor("unity", LuaUnitySettingsEditor())
+        return group
+    }
+
+    @Throws(ExecutionException::class)
+    override fun getState(executor: Executor, executionEnvironment: ExecutionEnvironment): RunProfileState? {
+        return LuaCommandLineState(executionEnvironment)
+    }
+
+    @Throws(WriteExternalException::class)
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        JDOMExternalizerUtil.writeField(element, "PreferedUnityInstanceName", preferedUnityInstanceName)
+    }
+
+    @Throws(InvalidDataException::class)
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        val preferedUnityInstanceName = JDOMExternalizerUtil.readField(element, "PreferedUnityInstanceName")
+        if (preferedUnityInstanceName != null)
+            this.preferedUnityInstanceName = preferedUnityInstanceName
+    }
+}

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfigurationFactory.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfigurationFactory.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class LuaUnityConfigurationFactory extends ConfigurationFactory {
 
-    LuaUnityConfigurationFactory(LuaUnityConfigurationType type) {
+    public LuaUnityConfigurationFactory(LuaUnityConfigurationType type) {
         super(type);
     }
 

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfigurationFactory.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfigurationFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.unity;
+
+import com.intellij.execution.BeforeRunTask;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.tang.intellij.lua.debugger.remote.LuaUnityConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ *
+ * Created by Taigacon on 2018/11/6.
+ */
+public class LuaUnityConfigurationFactory extends ConfigurationFactory {
+
+    LuaUnityConfigurationFactory(LuaUnityConfigurationType type) {
+        super(type);
+    }
+
+    @NotNull
+    @Override
+    public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
+        return new LuaUnityConfiguration(project, this);
+    }
+
+    @Override
+    public void configureBeforeRunTaskDefaults(Key<? extends BeforeRunTask> providerID, BeforeRunTask task) {
+        if ("Make".equals(providerID.toString()))
+            task.setEnabled(false);
+    }
+}

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfigurationType.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityConfigurationType.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.unity;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationType;
+import com.intellij.execution.configurations.ConfigurationTypeUtil;
+import com.tang.intellij.lua.lang.LuaIcons;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ *
+ * Created by Taigacon on 2018/11/6.
+ */
+public class LuaUnityConfigurationType implements ConfigurationType {
+
+    private final LuaUnityConfigurationFactory factory = new LuaUnityConfigurationFactory(this);
+
+    public static LuaUnityConfigurationType getInstance() {
+        return ConfigurationTypeUtil.findConfigurationType(LuaUnityConfigurationType.class);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Lua Attach Unity";
+    }
+
+    @Override
+    public String getConfigurationTypeDescription() {
+        return "Lua Attach Debugger";
+    }
+
+    @Override
+    public Icon getIcon() {
+        return LuaIcons.FILE;
+    }
+
+    @NotNull
+    @Override
+    public String getId() {
+        return "lua.unitydebug";
+    }
+
+    @Override
+    public ConfigurationFactory[] getConfigurationFactories() {
+        return new ConfigurationFactory[] { factory };
+    }
+}

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebugProcess.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebugProcess.kt
@@ -33,13 +33,11 @@ class LuaUnityDebugProcess internal constructor(session: XDebugSession, private 
 
     private fun queryUnityProcess(): ProcessInfo? {
         val list = UnityProcessDiscovery.getAttachableProcesses(GetProcessOptions.All)
-        if(list.isNotEmpty()){
+        if (list.isNotEmpty()) {
             var processMap = ProcessUtils.listProcesses()
-            for (processInfo in list){
-                val processDetailsInfo = processMap[processInfo.pid]
-                if(processDetailsInfo != null){
-                    var title = processDetailsInfo.title
-                    if(title.contains(configuration.preferedUnityInstanceName, false)){
+            for (processInfo in list) {
+                processMap[processInfo.pid]?.run {
+                    if (title.contains(configuration.preferedUnityInstanceName, false)) {
                         return processInfo
                     }
                 }
@@ -53,7 +51,7 @@ class LuaUnityDebugProcess internal constructor(session: XDebugSession, private 
         this.bridge = bridge
         bridge.setProtoHandler(this)
         val processInfo = queryUnityProcess()
-        if(processInfo == null){
+        if (processInfo == null) {
             if (configuration.preferedUnityInstanceName.isNotEmpty())
                 error("Cannot find suitable Unity instance for prefered instance name: ${configuration.preferedUnityInstanceName}")
             else

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebugProcess.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebugProcess.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.unity
+
+import com.intellij.execution.process.ProcessInfo
+import com.intellij.xdebugger.XDebugSession
+import com.tang.intellij.lua.debugger.attach.LuaAttachBridge
+import com.tang.intellij.lua.debugger.attach.LuaAttachBridgeBase
+import com.tang.intellij.lua.debugger.attach.LuaAttachDebugProcessBase
+import com.tang.intellij.lua.debugger.remote.LuaUnityConfiguration
+import com.tang.intellij.lua.debugger.utils.ProcessUtils
+
+/**
+ *
+ * Created by Taigacon on 2018/11/6.
+ */
+class LuaUnityDebugProcess internal constructor(session: XDebugSession, private val configuration: LuaUnityConfiguration)
+    : LuaAttachDebugProcessBase(session) {
+
+    private fun queryUnityProcess(): ProcessInfo? {
+        val list = UnityProcessDiscovery.GetAttachableProcesses(GetProcessOptions.All)
+        if(list.isNotEmpty()){
+            var processMap = ProcessUtils.listProcesses()
+            for (processInfo in list){
+                val processDetailsInfo = processMap[processInfo.pid]
+                if(processDetailsInfo != null){
+                    var title = processDetailsInfo.title
+                    if(title.contains(configuration.preferedUnityInstanceName, false)){
+                        return processInfo
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    override fun startBridge(): LuaAttachBridgeBase {
+        val bridge = LuaAttachBridge(this, session)
+        this.bridge = bridge
+        bridge.setProtoHandler(this)
+        val processInfo = queryUnityProcess()
+        if(processInfo == null){
+            if (configuration.preferedUnityInstanceName.isNotEmpty())
+                error("Cannot find suitable Unity instance for prefered instance name: ${configuration.preferedUnityInstanceName}")
+            else
+                error("Cannot find suitable Unity instance")
+            session.stop()
+        } else {
+            bridge.attach(processInfo)
+        }
+        return bridge
+    }
+}

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebugProcess.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebugProcess.kt
@@ -32,7 +32,7 @@ class LuaUnityDebugProcess internal constructor(session: XDebugSession, private 
     : LuaAttachDebugProcessBase(session) {
 
     private fun queryUnityProcess(): ProcessInfo? {
-        val list = UnityProcessDiscovery.GetAttachableProcesses(GetProcessOptions.All)
+        val list = UnityProcessDiscovery.getAttachableProcesses(GetProcessOptions.All)
         if(list.isNotEmpty()){
             var processMap = ProcessUtils.listProcesses()
             for (processInfo in list){

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebuggerRunner.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnityDebuggerRunner.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.unity;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.xdebugger.XDebugProcess;
+import com.intellij.xdebugger.XDebugProcessStarter;
+import com.intellij.xdebugger.XDebugSession;
+import com.intellij.xdebugger.XDebuggerManager;
+import com.tang.intellij.lua.debugger.LuaRunner;
+import com.tang.intellij.lua.debugger.remote.LuaUnityConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ *
+ * Created by Taigacon on 2018/11/6.
+ */
+public class LuaUnityDebuggerRunner extends LuaRunner {
+
+    private static final String ID = "lua.unity.runner";
+
+    @NotNull
+    @Override
+    public String getRunnerId() {
+        return ID;
+    }
+
+    @Override
+    public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
+        return DefaultDebugExecutor.EXECUTOR_ID.equals(executorId) && (runProfile instanceof LuaUnityConfiguration);
+    }
+
+    @Nullable
+    @Override
+    protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment environment) throws ExecutionException {
+        XDebugSession session = createSession(state, environment);
+        return session.getRunContentDescriptor();
+    }
+
+    private XDebugSession createSession(RunProfileState state, ExecutionEnvironment environment) throws ExecutionException {
+        XDebuggerManager manager = XDebuggerManager.getInstance(environment.getProject());
+        return manager.startSession(environment, new XDebugProcessStarter() {
+            @NotNull
+            @Override
+            public XDebugProcess start(@NotNull XDebugSession xDebugSession) throws ExecutionException {
+                return new LuaUnityDebugProcess(xDebugSession, (LuaUnityConfiguration)environment.getRunProfile());
+            }
+        });
+    }
+}

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnitySettingsEditor.form
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnitySettingsEditor.form
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.tang.intellij.lua.debugger.unity.LuaUnitySettingsEditor">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="d91f2" class="javax.swing.JTextField" binding="preferedUnityInstanceName">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <vspacer id="b6b7b">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="32725" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="d91f2"/>
+          <text value="&amp;PreferedUnityInstanceName:"/>
+        </properties>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnitySettingsEditor.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/LuaUnitySettingsEditor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.unity;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import com.tang.intellij.lua.debugger.remote.LuaUnityConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+/**
+ *
+ * Created by Taigacon on 2018/11/6.
+ */
+public class LuaUnitySettingsEditor extends SettingsEditor<LuaUnityConfiguration> {
+    private JTextField preferedUnityInstanceName;
+    private JPanel myPanel;
+
+    @Override
+    protected void resetEditorFrom(@NotNull LuaUnityConfiguration luaUnityConfiguration) {
+        preferedUnityInstanceName.setText(String.valueOf(luaUnityConfiguration.getPreferedUnityInstanceName()));
+    }
+
+    @Override
+    protected void applyEditorTo(@NotNull LuaUnityConfiguration luaUnityConfiguration) throws ConfigurationException {
+        luaUnityConfiguration.setPreferedUnityInstanceName(preferedUnityInstanceName.getText());
+    }
+
+    @NotNull
+    @Override
+    protected JComponent createEditor() {
+        preferedUnityInstanceName.addActionListener(e -> LuaUnitySettingsEditor.this.fireEditorStateChanged());
+        return myPanel;
+    }
+}

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/UnityProcessDiscovery.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/UnityProcessDiscovery.kt
@@ -52,7 +52,7 @@ class UnityProcessDiscovery {
             return processes
         }
 
-        private fun GetUnityEditorProcesses(): List<ProcessInfo> {
+        private fun getUnityEditorProcesses(): List<ProcessInfo> {
             val list = arrayListOf<ProcessInfo>()
             val systemProcesses = OSProcessUtil.getProcessList()
             for (processInfo in systemProcesses){

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/UnityProcessDiscovery.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/UnityProcessDiscovery.kt
@@ -41,13 +41,13 @@ class UnityProcessDiscovery {
         //private val unityProcessess = mutableListOf<ProcessInfo>()
         //private var unityProcessesFinished  = true
 
-        fun GetAttachableProcesses(flags: GetProcessOptions): List<ProcessInfo> {
+        fun getAttachableProcesses(flags: GetProcessOptions): List<ProcessInfo> {
             val processes = mutableListOf<ProcessInfo>()
             if (flags.hasFlag(GetProcessOptions.Editor)){
-                processes.addAll(GetUnityEditorProcesses())
+                processes.addAll(getUnityEditorProcesses())
             }
             //if (flags.hasFlag(GetProcessOptions.Players)){
-            //    processes.addAll(GetUnityPlayerProcesses(true))
+            //    processes.addAll(getUnityPlayerProcesses(true))
             //}
             return processes
         }

--- a/src/main/java/com/tang/intellij/lua/debugger/unity/UnityProcessDiscovery.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/unity/UnityProcessDiscovery.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.unity
+
+import com.intellij.execution.process.OSProcessUtil
+import com.intellij.execution.process.ProcessInfo
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+enum class GetProcessOptions(val v:Int) {
+    Editor(0x1),
+    Players(0x2),
+    All(Editor.v or Players.v);
+
+    fun hasFlag(flag: GetProcessOptions): Boolean{
+        return this.v and flag.v == flag.v
+    }
+}
+/**
+ *
+ * Created by Taigacon on 2018/11/6.
+ */
+class UnityProcessDiscovery {
+    companion object {
+        //private val mutex = ReentrantLock()
+
+        //private val unityProcessess = mutableListOf<ProcessInfo>()
+        //private var unityProcessesFinished  = true
+
+        fun GetAttachableProcesses(flags: GetProcessOptions): List<ProcessInfo> {
+            val processes = mutableListOf<ProcessInfo>()
+            if (flags.hasFlag(GetProcessOptions.Editor)){
+                processes.addAll(GetUnityEditorProcesses())
+            }
+            //if (flags.hasFlag(GetProcessOptions.Players)){
+            //    processes.addAll(GetUnityPlayerProcesses(true))
+            //}
+            return processes
+        }
+
+        private fun GetUnityEditorProcesses(): List<ProcessInfo> {
+            val list = arrayListOf<ProcessInfo>()
+            val systemProcesses = OSProcessUtil.getProcessList()
+            for (processInfo in systemProcesses){
+                if(processInfo.executableDisplayName == "Unity"){
+                    list.add(processInfo)
+                }
+            }
+            return list
+        }
+    }
+
+    class ConnectorRegistry {
+        private val processIdLock = ReentrantLock()
+        private var nextProcessId = 1000000
+        private val processIdToUniqueId = mutableMapOf<Int, String>()
+        private val uniqueIdToProcessId  = mutableMapOf<String, Int>()
+        //val connectors = mutableMapOf<Int, >()
+
+        fun getProcessIdForUniqueId(uid: String): Int{
+            processIdLock.withLock {
+                val processId = uniqueIdToProcessId[uid]
+                if(processId != null){
+                    return processId
+                }
+                val newProcessId = nextProcessId++
+                processIdToUniqueId.set(newProcessId, uid)
+                uniqueIdToProcessId.set(uid, newProcessId)
+                return newProcessId
+            }
+        }
+
+        fun getUniqueIdFromProcessId(processId: Int): String?{
+            processIdLock.withLock {
+                return processIdToUniqueId[processId]
+            }
+        }
+    }
+}

--- a/src/main/java/com/tang/intellij/lua/debugger/utils/ProcessUtils.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/utils/ProcessUtils.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017. tangzx(love.tangzx@qq.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tang.intellij.lua.debugger.utils
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.ProcessInfo
+import com.intellij.execution.util.ExecUtil
+import com.tang.intellij.lua.psi.LuaFileUtil
+import java.io.ByteArrayInputStream
+import javax.xml.parsers.DocumentBuilderFactory
+
+
+data class ProcessDetailInfo(
+        var pid: Int = 0,
+        var path: String = "",
+        var title: String = ""
+)
+
+private const val MAX_DISPLAY_LEN = 60
+
+internal fun getDisplayName(processInfo: ProcessInfo, detailInfo: ProcessDetailInfo): String {
+    val s = if (detailInfo.title.isNotEmpty())
+        "${processInfo.executableName} - ${detailInfo.title}"
+    else processInfo.executableName
+
+    if (s.length > MAX_DISPLAY_LEN)
+        return "${s.substring(0, MAX_DISPLAY_LEN)}..."
+    return s
+}
+
+
+class ProcessUtils {
+    companion object {
+        fun listProcesses(): Map<Int, ProcessDetailInfo> {
+            var processMap = mutableMapOf<Int, ProcessDetailInfo>()
+            val archExe = LuaFileUtil.getArchExeFile()
+            val commandLine = GeneralCommandLine(archExe)
+            //commandLine.charset = Charset.forName("UTF-8")
+            commandLine.addParameters("list_processes")
+
+            val processOutput = ExecUtil.execAndGetOutput(commandLine)
+
+            val text = processOutput.stdout
+            val builder = DocumentBuilderFactory.newInstance()
+            val documentBuilder = builder.newDocumentBuilder()
+            val document = documentBuilder.parse(ByteArrayInputStream(text.toByteArray()))
+            val root = document.documentElement
+            root.childNodes.let {
+                for (i in 0 until it.length) {
+                    val c = it.item(i)
+                    val p = ProcessDetailInfo()
+                    val map = c.attributes
+                    map.getNamedItem("pid")?.let {
+                        p.pid = it.nodeValue.toInt()
+                    }
+                    val childNodes = c.childNodes
+                    for (j in 0 until childNodes.length) {
+                        val child = childNodes.item(j)
+                        when (child.nodeName) {
+                            "title" -> {
+                                val item = child.childNodes.item(0)
+                                p.title = item?.nodeValue ?: ""
+                            }
+                            "path" -> {
+                                val item = child.childNodes.item(0)
+                                p.path = item?.nodeValue ?: ""
+                            }
+                        }
+                    }
+                    processMap[p.pid] = p
+                }
+            }
+            return processMap
+        }
+    }
+}

--- a/src/main/resources/META-INF/core.xml
+++ b/src/main/resources/META-INF/core.xml
@@ -149,6 +149,8 @@
         <configurationType implementation="com.tang.intellij.lua.debugger.remote.LuaMobConfigurationType"/>
         <programRunner implementation="com.tang.intellij.lua.debugger.app.LuaAppRunner"/>
         <configurationType implementation="com.tang.intellij.lua.debugger.app.LuaAppConfigurationType"/>
+        <programRunner implementation="com.tang.intellij.lua.debugger.unity.LuaUnityDebuggerRunner"/>
+        <configurationType implementation="com.tang.intellij.lua.debugger.unity.LuaUnityConfigurationType"/>
         <xdebugger.breakpointType implementation="com.tang.intellij.lua.debugger.LuaLineBreakpointType"/>
         <xdebugger.localAttachDebuggerProvider implementation="com.tang.intellij.lua.debugger.attach.LuaLocalAttachDebuggerProvider"/>
 


### PR DESCRIPTION
添加了一种Debug Configuration，可以自动找到Unity Editor的实例并且附加调试器到上面。
可选参数PreferedUnityInstanceName，如果Unity标题含有该字符串，才附加之。