### PR TITLE
Lua 5.0 - 5.2 Math std fixes

### DIFF
--- a/src/main/resources/std/Lua50/math.lua
+++ b/src/main/resources/std/Lua50/math.lua
@@ -34,11 +34,9 @@ function math.asin(x) return 0 end
 
 ---
 --- Returns the arc tangent of x (in radians).
----@overload fun(y:number):number
----@param y number
 ---@param x number
 ---@return number
-function math.atan(y, x) return 0 end
+function math.atan(x) return 0 end
 
 --- Returns the arc tangent of `y/x` (in radians), but uses the signs of both
 --- parameters to find the quadrant of the result. (It also handles correctly
@@ -82,13 +80,11 @@ function math.exp(x) end
 function math.floor(x) end
 
 ---
---- Returns the logarithm of `x` in the given base. The default for `base` is
---- *e* (so that the function returns the natural logarithm of `x`).
----@overload fun(x:number):number
+--- Returns the natural logarithm of x
 ---@param x number
 ---@param base number
 ---@return number
-function math.log(x, base) end
+function math.log(x) end
 
 --- Returns the base-10 logarithm of `x`.
 ---@param x number

--- a/src/main/resources/std/Lua50/math.lua
+++ b/src/main/resources/std/Lua50/math.lua
@@ -33,7 +33,7 @@ function math.acos(x) return 0 end
 function math.asin(x) return 0 end
 
 ---
---- Returns the arc tangent of x (in radians).
+--- Returns the arc tangent of `x` (in radians).
 ---@param x number
 ---@return number
 function math.atan(x) return 0 end

--- a/src/main/resources/std/Lua51/math.lua
+++ b/src/main/resources/std/Lua51/math.lua
@@ -108,9 +108,8 @@ math.huge = nil
 ---
 --- Returns the natural logarithm of `x`.
 ---@param x number
----@param base number
 ---@return number
-function math.log(x, base) end
+function math.log(x) end
 
 --- Returns the base-10 logarithm of `x`.
 ---@param x number

--- a/src/main/resources/std/Lua51/math.lua
+++ b/src/main/resources/std/Lua51/math.lua
@@ -33,12 +33,10 @@ function math.acos(x) return 0 end
 function math.asin(x) return 0 end
 
 ---
---- Returns the arc tangent of x (in radians).
----@overload fun(y:number):number
----@param y number
+--- Returns the arc tangent of `x` (in radians).
 ---@param x number
 ---@return number
-function math.atan(y, x) return 0 end
+function math.atan(x) return 0 end
 
 --- Returns the arc tangent of `y/x` (in radians), but uses the signs of both
 --- parameters to find the quadrant of the result. (It also handles correctly
@@ -108,9 +106,7 @@ function math.frexp(x) end
 math.huge = nil
 
 ---
---- Returns the logarithm of `x` in the given base. The default for `base` is
---- *e* (so that the function returns the natural logarithm of `x`).
----@overload fun(x:number):number
+--- Returns the natural logarithm of `x`.
 ---@param x number
 ---@param base number
 ---@return number

--- a/src/main/resources/std/Lua52/math.lua
+++ b/src/main/resources/std/Lua52/math.lua
@@ -34,7 +34,6 @@ function math.asin(x) return 0 end
 
 ---
 --- Returns the arc tangent of `x` (in radians).
----@param y number
 ---@param x number
 ---@return number
 function math.atan(x) return 0 end

--- a/src/main/resources/std/Lua52/math.lua
+++ b/src/main/resources/std/Lua52/math.lua
@@ -33,17 +33,11 @@ function math.acos(x) return 0 end
 function math.asin(x) return 0 end
 
 ---
---- Returns the arc tangent of `y/x` (in radians), but uses the signs of both
---- parameters to find the quadrant of the result. (It also handles correctly
---- the case of `x` being zero.)
----
---- The default value for `x` is 1, so that the call `math.atan(y)`` returns the
---- arc tangent of `y`.
----@overload fun(y:number):number
+--- Returns the arc tangent of `x` (in radians).
 ---@param y number
 ---@param x number
 ---@return number
-function math.atan(y, x) return 0 end
+function math.atan(x) return 0 end
 
 ---Returns the arc tangent of `y/x` (in radians), but uses the signs of both
 ---parameters to find the quadrant of the result. (It also handles correctly the


### PR DESCRIPTION
- **math.log** did not support optional arguments until 5.2
[math.log 5.2](https://www.lua.org/manual/5.2/manual.html#pdf-math.log)
[math.log 5.1](https://www.lua.org/manual/5.1/manual.html#pdf-math.log)
- **math.atan** did not support optional arguments until 5.3
[math.atan 5.3](https://www.lua.org/manual/5.3/manual.html#pdf-math.atan)
[math.atan 5.2](https://www.lua.org/manual/5.2/manual.html#pdf-math.atan)