### PR TITLE
Remove obsolete isEnforceTypeSafety() option

### DIFF
--- a/src/main/java/com/tang/intellij/lua/project/LuaSettings.kt
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettings.kt
@@ -43,9 +43,6 @@ class LuaSettings : PersistentStateComponent<LuaSettings> {
 
     var isShowWordsInFile: Boolean = true
 
-    // Throw errors if specified and found types do not match
-    var isEnforceTypeSafety: Boolean = false
-
     var isNilStrict: Boolean = false
 
     var isRecognizeGlobalNameAsType = true

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.form
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.form
@@ -103,7 +103,7 @@
           </component>
         </children>
       </grid>
-      <grid id="b2816" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="b2816" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -112,17 +112,9 @@
         <properties/>
         <border type="etched" title-resource-bundle="LuaBundle" title-key="ui.settings.type_safety"/>
         <children>
-          <component id="d66ed" class="javax.swing.JCheckBox" binding="enforceTypeSafety">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="LuaBundle" key="ui.settings.enforce_type_safety"/>
-            </properties>
-          </component>
           <component id="4e504" class="javax.swing.JCheckBox" binding="nilStrict">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="LuaBundle" key="ui.settings.strict_nil_checks"/>

--- a/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.java
+++ b/src/main/java/com/tang/intellij/lua/project/LuaSettingsPanel.java
@@ -45,7 +45,6 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
     private JCheckBox strictDoc;
     private JCheckBox smartCloseEnd;
     private JCheckBox showWordsInFile;
-    private JCheckBox enforceTypeSafety;
     private JCheckBox nilStrict;
     private JCheckBox recognizeGlobalNameAsCheckBox;
     private LuaAdditionalSourcesRootPanel additionalRoots;
@@ -61,7 +60,6 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
         strictDoc.setSelected(settings.isStrictDoc());
         smartCloseEnd.setSelected(settings.isSmartCloseEnd());
         showWordsInFile.setSelected(settings.isShowWordsInFile());
-        enforceTypeSafety.setSelected(settings.isEnforceTypeSafety());
         nilStrict.setSelected(settings.isNilStrict());
         recognizeGlobalNameAsCheckBox.setSelected(settings.isRecognizeGlobalNameAsType());
         additionalRoots.setRoots(settings.getAdditionalSourcesRoot());
@@ -105,7 +103,6 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
                 settings.isStrictDoc() != strictDoc.isSelected() ||
                 settings.isSmartCloseEnd() != smartCloseEnd.isSelected() ||
                 settings.isShowWordsInFile() != showWordsInFile.isSelected() ||
-                settings.isEnforceTypeSafety() != enforceTypeSafety.isSelected() ||
                 settings.isNilStrict() != nilStrict.isSelected() ||
                 settings.isRecognizeGlobalNameAsType() != recognizeGlobalNameAsCheckBox.isSelected() ||
                 settings.getEnableGeneric() != enableGenericCheckBox.isSelected() ||
@@ -123,7 +120,6 @@ public class LuaSettingsPanel implements SearchableConfigurable, Configurable.No
         settings.setStrictDoc(strictDoc.isSelected());
         settings.setSmartCloseEnd(smartCloseEnd.isSelected());
         settings.setShowWordsInFile(showWordsInFile.isSelected());
-        settings.setEnforceTypeSafety(enforceTypeSafety.isSelected());
         settings.setNilStrict(nilStrict.isSelected());
         settings.setRecognizeGlobalNameAsType(recognizeGlobalNameAsCheckBox.isSelected());
         settings.setAdditionalSourcesRoot(additionalRoots.getRoots());

--- a/src/main/resources/LuaBundle.properties
+++ b/src/main/resources/LuaBundle.properties
@@ -41,5 +41,4 @@ ui.settings.enable_generic=Enable generic
 ui.settings.additional_root=Lua additional sources root
 ui.settings.show_words=Show &words in file
 ui.settings.type_safety=Type safety
-ui.settings.enforce_type_safety=Enforce type safety
 ui.settings.strict_nil_checks=Strict nil checks


### PR DESCRIPTION
Thank you for making such a wonderful IntelliJ plugin!

I was wondering why the "Enforce type safety" option doesn't work until I checked up the source code. Looks like isn't used anywhere in the repository, and the preferred way to enable the additional diagnostics is to enable the type safety inspections.

So I thought it would be a good idea to remove the option entirely to not to confuse users.

Unfortunately, I didn't find any reasonable way to check if all things still work after the change, except running `./gradlew test` and checking if the patches for 171/172 platforms still apply. Please point me to the correct instructions if running the `test` task is not enough.