### PR TITLE
修复类型检查的问题

### DIFF
--- a/src/main/java/com/tang/intellij/lua/codeInsight/inspection/MatchFunctionSignatureInspection.kt
+++ b/src/main/java/com/tang/intellij/lua/codeInsight/inspection/MatchFunctionSignatureInspection.kt
@@ -51,7 +51,7 @@ class MatchFunctionSignatureInspection : StrictInspection() {
                     val prefixExpr = o.expr
                     val type = prefixExpr.guessType(searchContext)
 
-                    if (type is TyPsiFunction) {
+                    if (type is TyFunction) {
                         val perfectSig = type.findPerfectSignature(o)
                         annotateCall(o, perfectSig, searchContext)
                     } else if (prefixExpr is LuaIndexExpr) {

--- a/src/main/java/com/tang/intellij/lua/ty/Declarations.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/Declarations.kt
@@ -146,7 +146,7 @@ private fun LuaNameDef.infer(context: SearchContext): ITy {
             if (type !is ITyPrimitive)
                 type = type.union(TyClass.createAnonymousType(this))
             else if (type == Ty.TABLE)
-                type = TyClass.createAnonymousType(this)
+                type = type.union(TyClass.createAnonymousType(this))
         }
     }
     return type


### PR DESCRIPTION
发现类型检查存在两个问题：
1. 定义了类成员函数，却提示Unknown function
2. 函数返回table类型时，接收的变量不会被识别为table类型
简单修改了两个地方，看起来没问题了。