### PR TITLE
Some bug fix for attach debugger mode

### DIFF
--- a/debugger/attach/windows/src/EasyHookDll/EasyHookDll.vcxproj
+++ b/debugger/attach/windows/src/EasyHookDll/EasyHookDll.vcxproj
@@ -160,7 +160,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(SolutionDir)\DriverShared;$(SolutionDir);$(SolutionDir)\Public;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;EASYHOOK_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_ALLOW_RTCc_IN_STL;WIN32;_DEBUG;_WINDOWS;_USRDLL;EASYHOOK_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -240,7 +240,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <AdditionalIncludeDirectories>$(SolutionDir)\DriverShared;$(SolutionDir);$(SolutionDir)\Public;$(ProjectDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;_USRDLL;EASYHOOK_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_ALLOW_RTCc_IN_STL;WIN32;_WINDOWS;_USRDLL;EASYHOOK_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <ExceptionHandling>
       </ExceptionHandling>

--- a/debugger/attach/windows/src/EasyHookDll/LocalHook/debug.cpp
+++ b/debugger/attach/windows/src/EasyHookDll/LocalHook/debug.cpp
@@ -69,17 +69,17 @@ typedef LONG ZwQueryObject_PROC(
             ULONG InInfoSize,
             PULONG OutRequiredSize);
 
-typedef struct _CLIENT_ID
+typedef struct _DBG_CLIENT_ID
 {
     DWORD	    UniqueProcess;
     DWORD	    UniqueThread;
-}CLIENT_ID, * PCLIENT_ID;
+}DBG_CLIENT_ID, * PDBG_CLIENT_ID;
 
 typedef struct _THREAD_BASIC_INFORMATION
 {
     LONG ExitStatus;
     PNT_TIB TebBaseAddress;
-    CLIENT_ID ClientId;
+    DBG_CLIENT_ID ClientId;
     DWORD AffinityMask;
     LONG Priority;
     LONG BasePriority;

--- a/debugger/attach/windows/src/Shared/WindowUtility.cpp
+++ b/debugger/attach/windows/src/Shared/WindowUtility.cpp
@@ -2,6 +2,7 @@
 #include <tlhelp32.h>
 #include <psapi.h>
 #include <shlobj.h>
+#include <algorithm>
 
 HWND GetProcessWindow(DWORD processId)
 {
@@ -33,6 +34,34 @@ HWND GetProcessWindow(DWORD processId)
 
 }
 
+inline char char_tolower(char  c) {
+	return (char)tolower(c);
+}
+
+inline char char_toupper(char  c) {
+	return (char)toupper(c);
+}
+
+
+static void EmmyToLowerCase(std::string& str)
+{
+	std::transform(
+		str.begin(),
+		str.end(),
+		str.begin(),
+		char_tolower);
+}
+
+//-----------------------------------------------------------------------
+static void EmmyToUpperCase(std::string& str)
+{
+	std::transform(
+		str.begin(),
+		str.end(),
+		str.begin(),
+		char_toupper);
+}
+
 void GetProcesses(std::vector<Process>& processes)
 {
 	static char fileName[_MAX_PATH];
@@ -50,11 +79,21 @@ void GetProcesses(std::vector<Process>& processes)
 
 		if (Process32First(snapshot, &processEntry))
 		{
+			char windowsPath[MAX_PATH] = { 0 };
+			bool isGetWindowsPath = false;
+			std::string strWinPath;
+			if (SHGetFolderPath(nullptr, CSIDL_WINDOWS, nullptr, SHGFP_TYPE_CURRENT, windowsPath) == 0)
+			{
+				strWinPath = windowsPath;
+				EmmyToLowerCase(strWinPath);
+				isGetWindowsPath = true;
+			}
+
+
 			do
 			{
 				if (processEntry.th32ProcessID != currentProcessId && processEntry.th32ProcessID != 0)
 				{
-
 					Process process;
 
 					process.id = processEntry.th32ProcessID;
@@ -67,22 +106,62 @@ void GetProcesses(std::vector<Process>& processes)
 							process.path = "error";
 						else process.path = fileName;
 
-						if (!process.path.empty()) {
-							char windowsPath[MAX_PATH];
-							if (SHGetFolderPath(nullptr, CSIDL_WINDOWS, nullptr, SHGFP_TYPE_CURRENT, windowsPath) == 0) {
-								if (process.path.find(windowsPath) == std::string::npos) {
+						EmmyToLowerCase(process.path);
 
-									HWND hWnd = GetProcessWindow(processEntry.th32ProcessID);
+						if (!process.path.empty())
+						{
+							if (isGetWindowsPath &&  process.path.find(strWinPath.c_str()) != std::string::npos)
+							{
+								//on windows path exe
+								continue;
+							}
 
-									if (hWnd != nullptr)
-									{
-										char buffer[1024];
-										GetWindowText(hWnd, buffer, 1024);
-										process.title = buffer;
-									}
-									processes.push_back(process);
+							std::string skipExeNameList[] = {
+								"360se",
+								"MSBuild",
+								"vcpkgsrv",
+								"ServiceHub",
+								"VcxprojReader",
+								"mspdbsrv",
+								"TGitCache",
+								"TortoiseGitProc",
+								"devenv.exe",
+								"PerfWatson2",
+								"TSVNCache",
+								"steamwebhelper",
+								"UnrealCEFSubProcess",
+								"Microsoft.",
+								"VaCodeInspectionsServer",
+								"Steam.exe",
+							};
+
+							
+							size_t totalSkip = sizeof(skipExeNameList) / sizeof(skipExeNameList[0]);
+							bool needSkip = false;
+							for (int i = 0; i < totalSkip; i++)
+							{
+								EmmyToLowerCase(skipExeNameList[i]);
+								needSkip = process.path.find(skipExeNameList[i].c_str()) != std::string::npos;
+								if (needSkip)
+								{
+									break;
 								}
 							}
+
+							if (needSkip)
+							{
+								continue;
+							}
+
+							HWND hWnd = GetProcessWindow(processEntry.th32ProcessID);
+
+							if (hWnd != nullptr)
+							{
+								char buffer[1024];
+								GetWindowText(hWnd, buffer, 1024);
+								process.title = buffer;
+							}
+							processes.push_back(process);
 						}
 					}
 				}

--- a/debugger/attach/windows/src/emmy.backend/DebugBackend.h
+++ b/debugger/attach/windows/src/emmy.backend/DebugBackend.h
@@ -660,6 +660,9 @@ private:
 	bool                            m_profiler;
 	std::hash_map<std::string, LPFunctionCall*> m_profilerCallMap;
 	bool                            m_checkReloadNextTime;
+
+
+	CriticalSection					m_debugHookInstallLock;
 };
 
 #endif

--- a/debugger/attach/windows/src/emmy.backend/LuaTypes.h
+++ b/debugger/attach/windows/src/emmy.backend/LuaTypes.h
@@ -3,12 +3,15 @@
 // this is what we include instead of the standard Lua headers because there are mismatches that need to be taken care of at compile time
 // and obviously we can't include simultaneously the headers from several Lua versions
 
+
+constexpr auto LUA_IDSIZE = 1024;
+
 extern "C"
 {
 	// comes from luaconf.h, must match the configuration of the VM being debugged
 	// 注意：有的人会在 luaconf.h 里修改这个数值，所以这里直接把这个值改大一些，
 	// 为的是保证lua_Debug结构体的size比宿主的大，否则可能i_ci值异常
-	#define LUA_IDSIZE 1024
+	
 
 	// the lua_Debug structure changes between Lua 5.1 and Lua 5.2
 	struct lua_Debug_51

--- a/debugger/attach/windows/src/third-party/libpe/libpe/libpe.cpp
+++ b/debugger/attach/windows/src/third-party/libpe/libpe/libpe.cpp
@@ -279,7 +279,12 @@ PE_STATUS peParseBuffer( PE *pe )
 	if( pe->Headers.NT->OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC )
 	{
 		pe->Headers.Plus    = FALSE;
-		pe->Headers.OPT.p32 = &((PIMAGE_NT_HEADERS32)pe->Headers.NT)->OptionalHeader;
+#if _WIN64
+		pe->Headers.OPT.p64 = &pe->Headers.NT->OptionalHeader;
+#else
+		pe->Headers.OPT.p32 = &pe->Headers.NT->OptionalHeader;
+#endif
+		
 		pe->qwBaseAddress   = pe->Headers.OPT.p32->ImageBase;
 		pe->dwImageSize     = pe->Headers.OPT.p32->SizeOfImage;
 
@@ -584,7 +589,8 @@ PE_STATUS peParseExportTable( PE *pe, uint32_t dwMaxExports, uint32_t dwOptions 
 	ht_add( pe->ExportTable.ByAddress, (void *)(SYM)->Address.VA, (SYM) ); \
 	ht_add( pe->ExportTable.ByOrdinal, (void *)(SYM)->Ordinal, (SYM) )
 
-				dwMaxExports = min( dwMaxExports, pExportDirectory->NumberOfNames + pExportDirectory->NumberOfFunctions );
+				////dwMaxExports = min( dwMaxExports, pExportDirectory->NumberOfNames + pExportDirectory->NumberOfFunctions );
+				dwMaxExports = min(dwMaxExports, pExportDirectory->NumberOfFunctions);
 
 #pragma region Loop by Name
 

--- a/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachDebuggerProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/attach/LuaLocalAttachDebuggerProvider.kt
@@ -68,9 +68,12 @@ class LuaLocalAttachDebuggerProvider : XLocalAttachDebuggerProvider {
             userDataHolder.putUserData(DETAIL_KEY, processMap)
         }
 
-        if (processInfo.executableName.endsWith(".exe")) {
+        val lowcaseName = processInfo.executableName.toLowerCase()
+        if (lowcaseName.endsWith(".exe")) {
             val list = ArrayList<XLocalAttachDebugger>()
             val info = processMap[processInfo.pid]
+            //if (info != null && info.path.isNotEmpty() && !info.path.contains("windows", true)) {
+            //not need "windows" contain judgement here(already do in c++ code)
             if (info != null && info.path.isNotEmpty()) {
                 list.add(LuaLocalAttachDebugger(processInfo, info))
             }


### PR DESCRIPTION
2. [Bugfix] libpe not handle export function number right(will crash when use some dll such like ffmpeg avcodec-57.dll)
3. [Bugfix] Only check the first 1000 function in dlls
4. [Bugfix] All process path contain "Windows" will be skip in now version.
5. [Bugfix] When work in attach mode, hook start to work when dll not scaned finish, will lead to crash.
6. [Bugfix] When detach with a script error, lua on error handle will crash(Detach breaked the lua stack frame error handle needed)