### PR TITLE
Some bug fix for attach debugger mode & remote debug mode

### DIFF
--- a/debugger/attach/windows/src/EasyHookDll/LocalHook/debug.cpp
+++ b/debugger/attach/windows/src/EasyHookDll/LocalHook/debug.cpp
@@ -69,17 +69,17 @@ typedef LONG ZwQueryObject_PROC(
             ULONG InInfoSize,
             PULONG OutRequiredSize);
 
-typedef struct _CLIENT_ID
+typedef struct _DBG_CLIENT_ID
 {
     DWORD	    UniqueProcess;
     DWORD	    UniqueThread;
-}CLIENT_ID, * PCLIENT_ID;
+}DBG_CLIENT_ID, * PDBG_CLIENT_ID;
 
 typedef struct _THREAD_BASIC_INFORMATION
 {
     LONG ExitStatus;
     PNT_TIB TebBaseAddress;
-    CLIENT_ID ClientId;
+    DBG_CLIENT_ID ClientId;
     DWORD AffinityMask;
     LONG Priority;
     LONG BasePriority;

--- a/debugger/attach/windows/src/Shared/WindowUtility.cpp
+++ b/debugger/attach/windows/src/Shared/WindowUtility.cpp
@@ -2,6 +2,7 @@
 #include <tlhelp32.h>
 #include <psapi.h>
 #include <shlobj.h>
+#include <algorithm>
 
 HWND GetProcessWindow(DWORD processId)
 {
@@ -33,6 +34,34 @@ HWND GetProcessWindow(DWORD processId)
 
 }
 
+inline char char_tolower(char  c) {
+	return (char)tolower(c);
+}
+
+inline char char_toupper(char  c) {
+	return (char)toupper(c);
+}
+
+
+static void EmmyToLowerCase(std::string& str)
+{
+	std::transform(
+		str.begin(),
+		str.end(),
+		str.begin(),
+		char_tolower);
+}
+
+//-----------------------------------------------------------------------
+static void EmmyToUpperCase(std::string& str)
+{
+	std::transform(
+		str.begin(),
+		str.end(),
+		str.begin(),
+		char_toupper);
+}
+
 void GetProcesses(std::vector<Process>& processes)
 {
 	static char fileName[_MAX_PATH];
@@ -50,11 +79,21 @@ void GetProcesses(std::vector<Process>& processes)
 
 		if (Process32First(snapshot, &processEntry))
 		{
+			char windowsPath[MAX_PATH] = { 0 };
+			bool isGetWindowsPath = false;
+			std::string strWinPath;
+			if (SHGetFolderPath(nullptr, CSIDL_WINDOWS, nullptr, SHGFP_TYPE_CURRENT, windowsPath) == 0)
+			{
+				strWinPath = windowsPath;
+				EmmyToLowerCase(strWinPath);
+				isGetWindowsPath = true;
+			}
+
+
 			do
 			{
 				if (processEntry.th32ProcessID != currentProcessId && processEntry.th32ProcessID != 0)
 				{
-
 					Process process;
 
 					process.id = processEntry.th32ProcessID;
@@ -67,22 +106,62 @@ void GetProcesses(std::vector<Process>& processes)
 							process.path = "error";
 						else process.path = fileName;
 
-						if (!process.path.empty()) {
-							char windowsPath[MAX_PATH];
-							if (SHGetFolderPath(nullptr, CSIDL_WINDOWS, nullptr, SHGFP_TYPE_CURRENT, windowsPath) == 0) {
-								if (process.path.find(windowsPath) == std::string::npos) {
+						EmmyToLowerCase(process.path);
 
-									HWND hWnd = GetProcessWindow(processEntry.th32ProcessID);
+						if (!process.path.empty())
+						{
+							if (isGetWindowsPath &&  process.path.find(strWinPath.c_str()) != std::string::npos)
+							{
+								//on windows path exe
+								continue;
+							}
 
-									if (hWnd != nullptr)
-									{
-										char buffer[1024];
-										GetWindowText(hWnd, buffer, 1024);
-										process.title = buffer;
-									}
-									processes.push_back(process);
+							std::string skipExeNameList[] = {
+								"360se",
+								"MSBuild",
+								"vcpkgsrv",
+								"ServiceHub",
+								"VcxprojReader",
+								"mspdbsrv",
+								"TGitCache",
+								"TortoiseGitProc",
+								"devenv.exe",
+								"PerfWatson2",
+								"TSVNCache",
+								"steamwebhelper",
+								"UnrealCEFSubProcess",
+								"Microsoft.",
+								"VaCodeInspectionsServer",
+								"Steam.exe",
+							};
+
+							
+							size_t totalSkip = sizeof(skipExeNameList) / sizeof(skipExeNameList[0]);
+							bool needSkip = false;
+							for (int i = 0; i < totalSkip; i++)
+							{
+								EmmyToLowerCase(skipExeNameList[i]);
+								needSkip = process.path.find(skipExeNameList[i].c_str()) != std::string::npos;
+								if (needSkip)
+								{
+									break;
 								}
 							}
+
+							if (needSkip)
+							{
+								continue;
+							}
+
+							HWND hWnd = GetProcessWindow(processEntry.th32ProcessID);
+
+							if (hWnd != nullptr)
+							{
+								char buffer[1024];
+								GetWindowText(hWnd, buffer, 1024);
+								process.title = buffer;
+							}
+							processes.push_back(process);
 						}
 					}
 				}

--- a/debugger/attach/windows/src/emmy.arch/main.cpp
+++ b/debugger/attach/windows/src/emmy.arch/main.cpp
@@ -2,10 +2,13 @@
 #include <stdio.h>
 #include <string>
 #include <psapi.h>
+#include <algorithm>
 #include "Utility.h"
 #include "WindowUtility.h"
 
 using namespace std;
+
+
 
 int main(int argc, char** argv)
 {
@@ -29,10 +32,45 @@ int main(int argc, char** argv)
 			HANDLE m_process = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, processId);
 			GetModuleFileNameEx(m_process, nullptr, fileName, _MAX_PATH);
 
+			USHORT processMachine = 0, nativeMachine = 0;
+
+			typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS) (HANDLE, PBOOL);
+			LPFN_ISWOW64PROCESS fnIsWow64Process = nullptr;
+
+			typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS2) (HANDLE, USHORT*, USHORT*);
+			LPFN_ISWOW64PROCESS2 fnIsWow64Process2 = nullptr;
+
+			fnIsWow64Process2 = (LPFN_ISWOW64PROCESS2)GetProcAddress(
+				GetModuleHandle(TEXT("kernel32")), "IsWow64Process2");
+
+			fnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(
+				GetModuleHandle(TEXT("kernel32")), "IsWow64Process");
+
+			////fnIsWow64Process2 = nullptr;
+
 			ExeInfo info;
 			if (GetExeInfo(fileName, info)) {
-				printf("%d", info.i386);
-				return info.i386;
+				if (!info.managed)
+				{
+					printf("%d", info.i386);
+					return info.i386;
+				}
+				else
+				{
+					BOOL is64bit = FALSE;
+					if (fnIsWow64Process2)
+					{
+						is64bit = fnIsWow64Process2(m_process, &processMachine, &nativeMachine);
+					}
+					else if (fnIsWow64Process)
+					{
+						is64bit = fnIsWow64Process(m_process, &is64bit);
+					}
+
+					printf("%d", !is64bit);
+					return !is64bit;
+				}
+		
 			}
 		}
 	}

--- a/debugger/attach/windows/src/emmy.backend/DebugBackend.cpp
+++ b/debugger/attach/windows/src/emmy.backend/DebugBackend.cpp
@@ -996,8 +996,11 @@ void DebugBackend::HookCallback(LAPI api, lua_State* L, lua_Debug* ar)
 			if (m_mode == Mode_StepInto) {
 				stop = true;
 			}
-			else if (m_mode == Mode_StepOver) {
-				stop = vm->callCount == 0;
+			else if (m_mode == Mode_StepOver) 
+			{
+				int stackDepth = GetStackDepth(api, L);
+				stop = stop || (vm->callStackDepth >= stackDepth);
+				////stop = stop || (vm->callCount == 0);
 			}
 			else if (m_mode == Mode_StepOut) {
 				int stackDepth = GetStackDepth(api, L);

--- a/debugger/attach/windows/src/emmy.backend/DebugBackend.cpp
+++ b/debugger/attach/windows/src/emmy.backend/DebugBackend.cpp
@@ -1843,7 +1843,14 @@ int DebugBackend::ErrorHandler(LAPI api, lua_State* L)
 
 	if (!lua_isnil_dll(api, L, -1))
 	{
-		lua_pushvalue_dll(api, L, -2);
+		////lua_pushvalue_dll(api, L, -2);
+
+		////for (int i = -1; i>=-3; i--)
+		////{
+		////	int type = lua_type_dll(api, L, i);
+		////	const char* typeName = lua_typename_dll(api, L, type);
+		////}
+		lua_pushstring_dll(api, L, message);
 		lua_pcall_dll(api, L, 1, 1, 0);
 	}
 	else

--- a/debugger/attach/windows/src/emmy.backend/DebugBackend.h
+++ b/debugger/attach/windows/src/emmy.backend/DebugBackend.h
@@ -660,6 +660,9 @@ private:
 	bool                            m_profiler;
 	std::hash_map<std::string, LPFunctionCall*> m_profilerCallMap;
 	bool                            m_checkReloadNextTime;
+
+
+	CriticalSection					m_debugHookInstallLock;
 };
 
 #endif

--- a/debugger/attach/windows/src/emmy.backend/LuaTypes.h
+++ b/debugger/attach/windows/src/emmy.backend/LuaTypes.h
@@ -3,12 +3,15 @@
 // this is what we include instead of the standard Lua headers because there are mismatches that need to be taken care of at compile time
 // and obviously we can't include simultaneously the headers from several Lua versions
 
+
+constexpr auto LUA_IDSIZE = 1024;
+
 extern "C"
 {
 	// comes from luaconf.h, must match the configuration of the VM being debugged
 	// 注意：有的人会在 luaconf.h 里修改这个数值，所以这里直接把这个值改大一些，
 	// 为的是保证lua_Debug结构体的size比宿主的大，否则可能i_ci值异常
-	#define LUA_IDSIZE 1024
+	
 
 	// the lua_Debug structure changes between Lua 5.1 and Lua 5.2
 	struct lua_Debug_51

--- a/debugger/attach/windows/src/third-party/libpe/libpe/libpe.cpp
+++ b/debugger/attach/windows/src/third-party/libpe/libpe/libpe.cpp
@@ -279,7 +279,12 @@ PE_STATUS peParseBuffer( PE *pe )
 	if( pe->Headers.NT->OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC )
 	{
 		pe->Headers.Plus    = FALSE;
-		pe->Headers.OPT.p32 = &((PIMAGE_NT_HEADERS32)pe->Headers.NT)->OptionalHeader;
+#if _WIN64
+		pe->Headers.OPT.p64 = &pe->Headers.NT->OptionalHeader;
+#else
+		pe->Headers.OPT.p32 = &pe->Headers.NT->OptionalHeader;
+#endif
+		
 		pe->qwBaseAddress   = pe->Headers.OPT.p32->ImageBase;
 		pe->dwImageSize     = pe->Headers.OPT.p32->SizeOfImage;
 
@@ -584,7 +589,8 @@ PE_STATUS peParseExportTable( PE *pe, uint32_t dwMaxExports, uint32_t dwOptions 
 	ht_add( pe->ExportTable.ByAddress, (void *)(SYM)->Address.VA, (SYM) ); \
 	ht_add( pe->ExportTable.ByOrdinal, (void *)(SYM)->Ordinal, (SYM) )
 
-				dwMaxExports = min( dwMaxExports, pExportDirectory->NumberOfNames + pExportDirectory->NumberOfFunctions );
+				////dwMaxExports = min( dwMaxExports, pExportDirectory->NumberOfNames + pExportDirectory->NumberOfFunctions );
+				dwMaxExports = min(dwMaxExports, pExportDirectory->NumberOfFunctions);
 
 #pragma region Loop by Name
 

--- a/src/main/java/com/tang/intellij/lua/debugger/attach/LuaAttachDebugProcessBase.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/attach/LuaAttachDebugProcessBase.kt
@@ -133,6 +133,11 @@ abstract class LuaAttachDebugProcessBase protected constructor(session: XDebugSe
         bridge.send(LuaAttachMessage(DebugMessageId.StepOut))
     }
 
+    override fun startPausing() {
+        //super.startPausing()
+
+    }
+
     override fun stop() {
         bridge.stop()
     }

--- a/src/main/java/com/tang/intellij/lua/debugger/remote/LuaMobDebugProcess.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/remote/LuaMobDebugProcess.kt
@@ -69,6 +69,10 @@ open class LuaMobDebugProcess(session: XDebugSession) : LuaDebugProcess(session)
         mobClient?.addCommand("RUN")
     }
 
+    override fun startPausing() {
+        mobClient?.addCommand("SUSPEND")
+    }
+
     override fun startStepOver(context: XSuspendContext?) {
         mobClient?.addCommand("OVER")
     }

--- a/src/main/java/com/tang/intellij/lua/debugger/remote/LuaMobDebuggerEvaluator.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/remote/LuaMobDebuggerEvaluator.java
@@ -32,14 +32,16 @@ import org.luaj.vm2.lib.jse.JsePlatform;
  */
 public class LuaMobDebuggerEvaluator extends LuaDebuggerEvaluator {
     private LuaMobDebugProcess process;
+    private LuaMobStackFrame stackFrame;
 
-    public LuaMobDebuggerEvaluator(@NotNull LuaMobDebugProcess process) {
+    public LuaMobDebuggerEvaluator(@NotNull LuaMobDebugProcess process, @NotNull LuaMobStackFrame stackFrame) {
         this.process = process;
+        this.stackFrame = stackFrame;
     }
 
     @Override
     protected void eval(@NotNull String s, @NotNull XEvaluationCallback xEvaluationCallback, @Nullable XSourcePosition xSourcePosition) {
-        EvaluatorCommand evaluatorCommand = new EvaluatorCommand("return " + s, data -> {
+        EvaluatorCommand evaluatorCommand = new EvaluatorCommand("return " + s, this.stackFrame.getStackLevel(), data -> {
             Globals standardGlobals = JsePlatform.standardGlobals();
             LuaValue code = standardGlobals.load(data);
             code = code.call();

--- a/src/main/java/com/tang/intellij/lua/debugger/remote/LuaMobStackFrame.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/remote/LuaMobStackFrame.java
@@ -38,17 +38,19 @@ public class LuaMobStackFrame extends XStackFrame {
     private XSourcePosition position;
     private LuaMobDebugProcess process;
     private XValueChildrenList values = new XValueChildrenList();
+    private int stackLevel = 0;
 
-    public LuaMobStackFrame(String functionName, XSourcePosition position, LuaMobDebugProcess debugProcess) {
+    public LuaMobStackFrame(String functionName, XSourcePosition position, int _stackLevel, LuaMobDebugProcess debugProcess) {
         this.functionName = functionName;
         this.position = position;
+        this.stackLevel = _stackLevel;
         process = debugProcess;
     }
 
     @Nullable
     @Override
     public XDebuggerEvaluator getEvaluator() {
-        return  new LuaMobDebuggerEvaluator(process);
+        return  new LuaMobDebuggerEvaluator(process, this);
     }
 
     @Nullable
@@ -78,5 +80,10 @@ public class LuaMobStackFrame extends XStackFrame {
             info = String.format("%s (%s)", functionName, positionInfo);
         component.append(info, SimpleTextAttributes.REGULAR_ATTRIBUTES);
         component.setIcon(AllIcons.Debugger.StackFrame);
+    }
+
+    public int getStackLevel()
+    {
+        return this.stackLevel;
     }
 }

--- a/src/main/java/com/tang/intellij/lua/debugger/remote/commands/EvaluatorCommand.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/remote/commands/EvaluatorCommand.kt
@@ -23,7 +23,7 @@ import java.util.regex.Pattern
  *
  * Created by tangzx on 2017/1/1.
  */
-class EvaluatorCommand(expr: String, private val callback: Callback) : DefaultCommand("EXEC $expr --{maxlevel=1}", 2) {
+class EvaluatorCommand(expr: String, stackLevel: Int, private val callback: Callback) : DefaultCommand("EXEC $expr --{maxlevel=1, stack=$stackLevel}", 2) {
     private var hasError2Process: Boolean = false
     private var dataLen: Int = 0
     private val dataBuffer = StringBuffer()

--- a/src/main/java/com/tang/intellij/lua/debugger/remote/commands/GetStackCommand.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/remote/commands/GetStackCommand.kt
@@ -90,7 +90,7 @@ class GetStackCommand : DefaultCommand("STACK --{maxlevel=0}", 1) {
                 if (funcName.isnil())
                     functionName = "main"
 
-                val frame = LuaMobStackFrame(functionName, position, debugProcess)
+                val frame = LuaMobStackFrame(functionName, position, i, debugProcess)
 
                 parseValues(stackValue.get(2).checktable(), frame)
                 parseValues(stackValue.get(3).checktable(), frame)

--- a/src/main/java/com/tang/intellij/lua/debugger/remote/commands/GetStackCommand.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/remote/commands/GetStackCommand.kt
@@ -31,7 +31,7 @@ import java.util.regex.Pattern
  *
  * Created by tangzx on 2016/12/31.
  */
-class GetStackCommand : DefaultCommand("STACK --{maxlevel=10}", 1) {
+class GetStackCommand : DefaultCommand("STACK --{maxlevel=0}", 1) {
 
     private var hasError: Boolean = false
     private var errorDataLen: Int = 0


### PR DESCRIPTION
1. [Bugfix] lua5.2+ support fix  …
2. [Bugfix] libpe not handle export function number right(will crash when use some dll such like ffmpeg avcodec-57.dll)
3. [Bugfix] Only check the first 1000 function in dlls
4. [Bugfix] All process path contain "Windows" will be skip in now version.
5. [Bugfix] When work in attach mode, hook start to work when dll not scaned finish, will lead to crash.
6. [Bugfix] When detach with a script error, lua on error handle will crash(Detach breaked the lua stack frame error handle needed)
7. [Bugfix] Mobdebug stack level support
8. [Bugfix] Mobdebug request not needed table level for stack command
9. add suspend for mobdebug