### PR TITLE
String literal type checking

### DIFF
--- a/src/main/java/com/tang/intellij/lua/comment/psi/LuaDocPsiImplUtil.kt
+++ b/src/main/java/com/tang/intellij/lua/comment/psi/LuaDocPsiImplUtil.kt
@@ -277,7 +277,7 @@ fun getType(luaDocParTy: LuaDocParTy): ITy {
 
 fun getType(stringLiteral: LuaDocStringLiteralTy): ITy {
     val text = stringLiteral.text
-    return TyStringLiteral(if (text.length >= 2) text.substring(1, text.length - 1) else "")
+    return TyStringLiteral.getTy(if (text.length >= 2) text.substring(1, text.length - 1) else "")
 }
 
 fun getType(unionTy: LuaDocUnionTy): ITy {

--- a/src/main/java/com/tang/intellij/lua/ty/Declarations.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/Declarations.kt
@@ -140,8 +140,12 @@ private fun LuaNameDef.infer(context: SearchContext): ITy {
                 }
             }
 
+            if (type is TyStringLiteral) {
+                type = Ty.STRING // Variables that aren't explicitly doc-typed as a literal, are best treated as a string primitive.
+            }
+
             //anonymous
-            if (type !is ITyPrimitive)
+            if (type !is TyStringLiteral && type !is ITyPrimitive)
                 type = type.union(TyClass.createAnonymousType(this))
             else if (type == Ty.TABLE)
                 type = type.union(TyClass.createAnonymousType(this))

--- a/src/main/java/com/tang/intellij/lua/ty/Expressions.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/Expressions.kt
@@ -18,11 +18,13 @@ package com.tang.intellij.lua.ty
 
 import com.intellij.openapi.util.Computable
 import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Processor
 import com.tang.intellij.lua.Constants
 import com.tang.intellij.lua.ext.recursionGuard
+import com.tang.intellij.lua.lang.type.LuaString
 import com.tang.intellij.lua.project.LuaSettings
 import com.tang.intellij.lua.psi.*
 import com.tang.intellij.lua.psi.impl.LuaNameExprMixin
@@ -305,7 +307,7 @@ private fun isGlobal(nameExpr: LuaNameExpr):Boolean {
 private fun LuaLiteralExpr.infer(): ITy {
     return when (this.kind) {
         LuaLiteralKind.Bool -> Ty.BOOLEAN
-        LuaLiteralKind.String -> Ty.STRING
+        LuaLiteralKind.String -> TyStringLiteral.getTy("'" + LuaString.getContent(firstChild.text).value + "'")
         LuaLiteralKind.Number -> Ty.NUMBER
         LuaLiteralKind.Varargs -> {
             val o = PsiTreeUtil.getParentOfType(this, LuaFuncBodyOwner::class.java)

--- a/src/main/java/com/tang/intellij/lua/ty/TyStringLiteral.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyStringLiteral.kt
@@ -18,9 +18,14 @@ package com.tang.intellij.lua.ty
 
 import com.intellij.psi.stubs.StubInputStream
 import com.intellij.psi.stubs.StubOutputStream
+import com.tang.intellij.lua.search.SearchContext
 
 class TyStringLiteral(val content: String) : Ty(TyKind.StringLiteral) {
     override fun toString() = content
+
+    override fun subTypeOf(other: ITy, context: SearchContext, strict: Boolean): Boolean {
+        return other == STRING || super.subTypeOf(other, context, strict)
+    }
 }
 
 object TyStringLiteralSerializer : TySerializer<TyStringLiteral>() {

--- a/src/main/java/com/tang/intellij/lua/ty/TyStringLiteral.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyStringLiteral.kt
@@ -19,8 +19,18 @@ package com.tang.intellij.lua.ty
 import com.intellij.psi.stubs.StubInputStream
 import com.intellij.psi.stubs.StubOutputStream
 import com.tang.intellij.lua.search.SearchContext
+import java.util.concurrent.ConcurrentHashMap
 
-class TyStringLiteral(val content: String) : Ty(TyKind.StringLiteral) {
+
+class TyStringLiteral private constructor(val content: String) : Ty(TyKind.StringLiteral) {
+    companion object {
+        private val stringLiterals = ConcurrentHashMap<String, TyStringLiteral>()
+
+        fun getTy(content: String): TyStringLiteral {
+            return stringLiterals.getOrPut(content, { TyStringLiteral(content) })
+        }
+    }
+
     override fun toString() = content
 
     override fun subTypeOf(other: ITy, context: SearchContext, strict: Boolean): Boolean {
@@ -30,7 +40,7 @@ class TyStringLiteral(val content: String) : Ty(TyKind.StringLiteral) {
 
 object TyStringLiteralSerializer : TySerializer<TyStringLiteral>() {
     override fun deserializeTy(flags: Int, stream: StubInputStream): TyStringLiteral {
-        return TyStringLiteral(stream.readUTF())
+        return TyStringLiteral.getTy(stream.readUTF())
     }
 
     override fun serializeTy(ty: TyStringLiteral, stream: StubOutputStream) {

--- a/src/main/java/com/tang/intellij/lua/ty/TyUnion.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyUnion.kt
@@ -41,7 +41,7 @@ class TyUnion : Ty(TyKind.Union) {
     }
 
     override fun subTypeOf(other: ITy, context: SearchContext, strict: Boolean): Boolean {
-        return super.subTypeOf(other, context, strict) || childSet.any { type -> type.subTypeOf(other, context, strict) }
+        return super.subTypeOf(other, context, strict) || childSet.all { type -> type.subTypeOf(other, context, strict) }
     }
 
     override fun substitute(substitutor: ITySubstitutor): ITy {


### PR DESCRIPTION
String literals are now a real type-checked type.

* String literals are assignable to strings, but not vice versa.
* Name definitions are assumed to be primitive strings, unless explicitly typed as a string primitive i.e. the following is valid:
    ```lua
    local mutateMe = "hi"
    mutateMe = "hi" .. " there"
    ```
* To type (pseudo-)constants you can do:
    ```lua
    ---@type "'hi'"
    local SOME_CONSTANT = "hi"
    SOME_CONSTANT = "something else" -- Raises a type assignment error
    ```
* Functions that have explicit string literals (or unions there-of) now enforce these e.g.
    ```lua
    ---@param axis "'x'"|"'y'"|"'z'"
    local function takesLiterals(axis)
    end

    takesLiterals("x")
    takesLiterals("y")
    takesLiterals("z")
    takesLiterals("q") -- Raises error

    local nonLiteralString = "x"
    takesLiterals(nonLiteralString) -- Raises error

    ---@type "'x'"
    local literalString = "x"
    takesLiterals(literalString)
    ```
* Included in this PR is a fix for union sub-type detection. It was incorrectly detecting `string|number` as a sub-type of `number` where as that is clearly unsound as `string` is not a sub-type of `number` etc.