### PR TITLE
added functions to invalidate InferCache

### DIFF
--- a/src/main/java/com/tang/intellij/lua/search/SearchContext.kt
+++ b/src/main/java/com/tang/intellij/lua/search/SearchContext.kt
@@ -100,6 +100,11 @@ class SearchContext private constructor(val project: Project) {
                 ret
             }
         }
+
+        fun invalidateCache(project: Project) {
+            var searchContext = get(project)
+            searchContext.invalidateInferCache()
+        }
     }
 
     /**
@@ -173,5 +178,9 @@ class SearchContext private constructor(val project: Project) {
 
     fun getTypeFromCache(psi: LuaTypeGuessable): ITy {
         return myInferCache.getOrElse(psi) { Ty.UNKNOWN }
+    }
+
+    fun invalidateInferCache() {
+        myInferCache.clear()
     }
 }


### PR DESCRIPTION
This will allow plugins, that rely on creating their own TypeInfer to invalidate the InferCache, when they have new knowledge about some type (e.g. when addtional indexing is finished or creating new sources is finished).

I am not sure, if this is completely correct, but in my tests, that works fine.