### PR TITLE
Implemented "Multiple expressions in one line" wrapping setting

### DIFF
--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
@@ -66,6 +66,7 @@ class LuaLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
 
                         // keep when reformatting
                         "KEEP_SIMPLE_BLOCKS_IN_ONE_LINE",
+                        "KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE",
 
                         //align group declarations
                         "ALIGN_CONSECUTIVE_VARIABLE_DECLARATIONS"

--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
@@ -64,6 +64,8 @@ class LuaLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
                         "CALL_PARAMETERS_WRAP",
                         "ALIGN_MULTILINE_PARAMETERS_IN_CALLS",
 
+                        "ALIGN_MULTILINE_CHAINED_METHODS",
+
                         // keep when reformatting
                         "KEEP_SIMPLE_BLOCKS_IN_ONE_LINE",
                         "KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE",

--- a/src/main/java/com/tang/intellij/lua/editor/formatter/blocks/LuaIndexExprBlock.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/blocks/LuaIndexExprBlock.kt
@@ -31,14 +31,16 @@ class LuaIndexExprBlock(psi: LuaIndexExpr, wrap: Wrap?, alignment: Alignment?, i
     private val dotAlign = Alignment.createAlignment(true)
 
     private val align: Alignment? get() {
-        val p = parentBlock ?: return dotAlign
-        if (p is LuaIndexExprBlock)
-            return p.align
-        else {
-            if (p.elementType == LuaTypes.CALL_EXPR) {
-                val pp = p.parentBlock
-                if (pp is LuaIndexExprBlock)
-                    return pp.align
+        if (ctx.settings.ALIGN_MULTILINE_CHAINED_METHODS) {
+            val p = parentBlock ?: return dotAlign
+            if (p is LuaIndexExprBlock)
+                return p.align
+            else {
+                if (p.elementType == LuaTypes.CALL_EXPR) {
+                    val pp = p.parentBlock
+                    if (pp is LuaIndexExprBlock)
+                        return pp.align
+                }
             }
         }
         return dotAlign

--- a/src/main/java/com/tang/intellij/lua/editor/formatter/blocks/LuaScriptBlock.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/blocks/LuaScriptBlock.kt
@@ -139,9 +139,11 @@ open class LuaScriptBlock(val psi: PsiElement,
     }
 
     override fun getSpacing(child1: Block?, child2: Block): Spacing? {
-        if ((child1 is LuaScriptBlock && child1.psi is LuaStatement) &&
-                (child2 is LuaScriptBlock && child2.psi is LuaStatement)) {
-            return Spacing.createSpacing(1, 0, 1, true, 1)
+        if (!ctx.settings.KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE) {
+            if ((child1 is LuaScriptBlock && child1.psi is LuaStatement) &&
+                    (child2 is LuaScriptBlock && child2.psi is LuaStatement)) {
+                return Spacing.createSpacing(1, 0, 1, true, 1)
+            }
         }
         return ctx.spaceBuilder.getSpacing(this, child1, child2)
     }


### PR DESCRIPTION
This enables the user to configure wether they'd like to every statement to be on a single line or not.

Some examples of where multiple statements on a line could be used in Lua:
```
local object = createMyObject({
    width = 16,
    height = 16
}); object:playAnimation()
```

or 
```
local newString = string.gsub(oldString, "_suffix", ""); print(newString)
```