### PR TITLE
Initial support for Inlay Param Exclude list...

### DIFF
--- a/src/main/java/com/tang/intellij/lua/codeInsight/LuaParameterHintsProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/codeInsight/LuaParameterHintsProvider.kt
@@ -27,11 +27,7 @@ import com.tang.intellij.lua.lang.*
 import com.tang.intellij.lua.search.SearchContext
 import com.tang.intellij.lua.ty.*
 import java.util.*
-import com.intellij.codeInsight.hints.settings.ParameterNameHintsSettings
-import com.intellij.ide.plugins.PluginManager
-import com.intellij.openapi.diagnostic.Logger
 import com.tang.intellij.lua.LuaBundle
-import com.tang.intellij.lua.psi.impl.LuaCallExprImpl
 import com.tang.intellij.lua.psi.impl.LuaListArgsImpl
 import java.util.stream.Collectors
 
@@ -42,8 +38,6 @@ import java.util.stream.Collectors
 class LuaParameterHintsProvider : InlayParameterHintsProvider {
 
     companion object {
-        private val log: Logger = Logger.getInstance("JOCHEM")
-
         private val ARGS_HINT = Option("lua.hints.show_args_type",
                 "Show argument name hints",
                 true)

--- a/src/main/resources/LuaBundle.properties
+++ b/src/main/resources/LuaBundle.properties
@@ -49,5 +49,8 @@ To disable hints for a function use the appropriate pattern: \
 <p> \
     <code><b>math.*<b></code><br> \
     <code><b>*.insert*<b></code><br> \
+    <code>(*_)</code> - single parameter function where the parameter name ends with <i>_</i><br /> \
+    <code>(key, value)</code> - functions with parameters <i>key</i> and <i>value</i><br /> \
+    <code>*.put(key, value)</code> - <i>put</i> functions with <i>key</i> and <i>value</i> parameters \
 </p> \
 </html>

--- a/src/main/resources/LuaBundle.properties
+++ b/src/main/resources/LuaBundle.properties
@@ -44,3 +44,10 @@ ui.settings.type_safety=Type safety
 ui.settings.enforce_type_safety=Enforce type safety
 ui.settings.strict_nil_checks=Strict nil checks
 ui.settings.require_like_function_names=&Require-like function names:
+inlay.hints.blacklist.pattern.explanation=<html> \
+To disable hints for a function use the appropriate pattern: \
+<p> \
+    <code><b>math.*<b></code><br> \
+    <code><b>*.insert*<b></code><br> \
+</p> \
+</html>


### PR DESCRIPTION
This adds the `Exclude list...`options to the Inlay Param configuration which opens the list dialog
In this dialog you can enter some exceptions for when not to show Inlay Params:

e.g.
`*.insert*` will cancel Inlay Params on all insert methods
`math.*` will cancel Inlay Params on all math.* methods

This method uses a simple variant of the Exclude list by just looking at the actual line of code