### PR TITLE
Updated SpacingBuilder to allow code next to if statement if preferred

### DIFF
--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaFormattingModelBuilder.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaFormattingModelBuilder.kt
@@ -51,9 +51,11 @@ class LuaFormattingModelBuilder : FormattingModelBuilder {
 
         return SpacingBuilder(settings, LuaLanguage.INSTANCE)
                 .before(END).lineBreakInCode()
-                .after(DO).lineBreakInCode()
-                .after(THEN).lineBreakInCode()
-                .around(ELSE).lineBreakInCode()
+                .after(DO).spaces(1)
+                .after(THEN).spaces(1)
+                .after(ELSE).spaces(1)
+                .before(ELSE).lineBreakInCode()
+                .after(ELSEIF).spaces(1)
                 .before(ELSEIF).lineBreakInCode()
                 .after(LOCAL).spaces(1) //local<SPACE>
                 .around(COLON).none()
@@ -65,7 +67,7 @@ class LuaFormattingModelBuilder : FormattingModelBuilder {
                 .before(TABLE_FIELD_SEP).none() // { 1<SPACE>, 2 }
                 .after(TABLE_FIELD_SEP).spaces(if (luaCodeStyleSettings.SPACE_AFTER_TABLE_FIELD_SEP) 1 else 0) // { 1,<SPACE>2 }
                 .before(BLOCK).blankLines(0)
-                .afterInside(RPAREN, FUNC_BODY).lineBreakInCode()
+                .afterInside(RPAREN, FUNC_BODY).spaces(1)
                 .between(FUNCTION, FUNC_BODY).none()
                 .between(FUNCTION, NAME_DEF).spaces(1) //function<SPACE>name()
                 .around(BINARY_OP).spaces(if (luaCodeStyleSettings.SPACE_AROUND_BINARY_OPERATOR) 1 else 0)


### PR DESCRIPTION
Because of the lineBreakInCode() in the 'befores' we still get the same behavior as behavior which automatically aligns the 'end' for example. But comments are not automatically moved to the if's body

```
    local t = {}
    function t:a() -- this comment was always allowed since there was no code in the body
    
    end
    
    function t:b() -- this comment is now allowed
        local randomNumber = math.random(10)
        if randomNumber < 2 then -- this comment is now allowed
            return 1
        elseif randomNumber < 4 then -- this comment was always allowed since there was no code in the body
        
        else -- this comment is now allowed
            local test = 1
        end
    end
    
    return t
```