### PR TITLE
Fixed wrong endType symbol in UnmatchedBraceHandler

### DIFF
--- a/src/main/java/com/tang/intellij/lua/braces/LuaBraceMatcher.kt
+++ b/src/main/java/com/tang/intellij/lua/braces/LuaBraceMatcher.kt
@@ -37,8 +37,8 @@ class LuaBraceMatcher : PairedBraceMatcher {
         return true
     }
 
-    override fun getCodeConstructStart(psiFile: PsiFile, i: Int): Int {
-        return i
+    override fun getCodeConstructStart(psiFile: PsiFile, openingOffset: Int): Int {
+        return openingOffset
     }
 
     companion object {

--- a/src/main/java/com/tang/intellij/lua/editor/LuaEnterAfterUnmatchedBraceHandler.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/LuaEnterAfterUnmatchedBraceHandler.kt
@@ -67,6 +67,7 @@ class LuaEnterAfterUnmatchedBraceHandler : EnterHandlerDelegate {
             var shouldClose = false
             var range: PsiElement? = null
             var cur: PsiElement = lElement
+            val endTypeAtCaret = getEnd(cur.parent.node.elementType)
             while (true) {
                 val searched = cur.parent
                 if (searched == null || searched is PsiFile) break
@@ -86,9 +87,9 @@ class LuaEnterAfterUnmatchedBraceHandler : EnterHandlerDelegate {
                 val endType = getEnd(range.node.elementType)
                 val document = editor.document
                 if (rElement !is PsiWhiteSpace)
-                    document.insertString(caretOffset, "$endType ")
+                    document.insertString(caretOffset, "$endTypeAtCaret ")
                 else
-                    document.insertString(caretOffset, "$endType")
+                    document.insertString(caretOffset, "$endTypeAtCaret")
                 editorActionHandler?.execute(editor, editor.caretModel.currentCaret, dataContext)
 
                 val project = lElement.project


### PR DESCRIPTION
The current handler sometimes entered the wrong endType, this should fix it. Previously the following code would add a '}' instead of end

```
local test = {
    fun = function()
        if true then[CARET_IS_HERE]

    end
}
```