### PR TITLE
修复调试时修改代码，断点无法正确移动的bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ val buildVersion = System.getProperty("IDEA_VER") ?: buildDataList.first().ideaS
 
 val buildVersionData = buildDataList.find { it.ideaSDKShortVersion == buildVersion }!!
 
-val emmyDebuggerVersion = "1.2.9"
+val emmyDebuggerVersion = "1.3.0"
 
 val resDir = "src/main/resources"
 

--- a/src/main/java/com/tang/intellij/lua/debugger/LuaDebugProcess.kt
+++ b/src/main/java/com/tang/intellij/lua/debugger/LuaDebugProcess.kt
@@ -43,6 +43,7 @@ abstract class LuaDebugProcess protected constructor(session: XDebugSession) : X
 
     override fun sessionInitialized() {
         super.sessionInitialized()
+        session.setPauseActionSupported(true)
         session.consoleView.addMessageFilter(LuaTracebackFilter(session.project))
     }
 


### PR DESCRIPTION
emmylua一万个BUG之一：断点调试时，修改代码导致断点的行变更，从而断点无法正确移除和新增。导致项目中存在许多隐藏的断点。