### PR TITLE
Fixed suggestions when providing generic type of `self` as the first parameter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,9 +19,9 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.io.ByteArrayOutputStream
 
 plugins {
-    id("org.jetbrains.intellij").version("1.10.0")
-    id("org.jetbrains.kotlin.jvm").version("1.7.22")
+    id("org.jetbrains.intellij").version("1.13.2")
     id("de.undercouch.download").version("5.3.0")
+    kotlin("jvm") version "1.7.22"
 }
 
 data class BuildData(
@@ -265,4 +265,10 @@ project(":") {
             }
         }
     }
+}
+dependencies {
+    implementation(kotlin("stdlib"))
+}
+repositories {
+    mavenCentral()
 }

--- a/src/main/java/com/tang/intellij/lua/ty/Ty.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/Ty.kt
@@ -177,6 +177,11 @@ abstract class Ty(override val kind: TyKind) : ITy {
     override fun eachTopClass(fn: Processor<ITyClass>) {
         when (this) {
             is ITyClass -> fn.process(this)
+            is ITyGeneric -> {
+                if(this.base is ITyClass) {
+                    fn.process(this.base as ITyClass)
+                }
+            }
             is TyUnion -> {
                 ContainerUtil.process(getChildTypes()) {
                     if (it is ITyClass && !fn.process(it))

--- a/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
+++ b/src/main/java/com/tang/intellij/lua/ty/TyClass.kt
@@ -165,6 +165,10 @@ abstract class TyClass(override val className: String,
         if (other == Ty.TABLE) return true
         if (super.subTypeOf(other, context, strict)) return true
 
+		if (other is ITyGeneric) {
+			return subTypeOf(other.base, context, strict)
+		}
+
         // Lazy init for superclass
         this.doLazyInit(context)
         // Check if any of the superclasses are type
@@ -189,7 +193,7 @@ abstract class TyClass(override val className: String,
          * to be initialized. So the JVM can't run `createSerializedClass` without
          * having `TyClass`, and it can't use `TyClass` without running `createSerializedClass`.
          * Thus the JVM deadlocks during classloading, resulting in frozen indexing...
-         * 
+         *
          * Workaround this by using Kotlin lazy properties,
          * so `createSerializedClass` is not run until TyClass.G is actually accessed.
          *


### PR DESCRIPTION
Previously, there was an issue where if you provided a generic to a type, it would not properly suggest functions.

As you can see, if there is no generic, it properly suggests the function.
![image](https://user-images.githubusercontent.com/29933214/226504293-93be43a9-8d4a-4ff8-9aa3-0ba10eddfd38.png)

However, if there is a generic, it doesn't properly suggest the function.
![image](https://user-images.githubusercontent.com/29933214/226504440-acd5f9c7-69d1-461c-a0f9-0ebea91c7ee1.png)

This commit fixes that.

Furthermore, there was an issue where if you provided a generic type to the first parameter of a non-self function, it would not suggest it. It would suggest it if it wasn't a generic.
![image](https://user-images.githubusercontent.com/29933214/226504173-87a5909f-61d5-476b-bd70-859698e37215.png)


![image](https://user-images.githubusercontent.com/29933214/226503725-948169f3-d42f-47a6-b90a-33f19238b54e.png)

This commit also fixes that.

Note: I modified the gradle build file because it wouldn't properly build on my setup for some reason.