### PR TITLE
增强字符串信息可视化

### DIFF
--- a/src/main/java/com/tang/intellij/lua/debugger/emmy/EmmyDebugSettingsPanel.java
+++ b/src/main/java/com/tang/intellij/lua/debugger/emmy/EmmyDebugSettingsPanel.java
@@ -207,6 +207,14 @@ public class EmmyDebugSettingsPanel extends SettingsEditor<EmmyDebugConfiguratio
 
     private void updateCodeImpl() {
         StringBuilder sb = new StringBuilder();
+
+        sb.append("local EmmyStringOutputMode = {\n")
+                .append("    Auto = 'Auto',\n")
+                .append("    Concise = 'Concise',\n")
+                .append("    Complete = 'Complete',\n")
+                .append("}\n")
+                .append("rawset(_G, 'EmmyStringOutputMode', EmmyStringOutputMode.Auto)\n");
+
         if (SystemInfoRt.isWindows) {
             EmmyWinArch arch = x64RadioButton.isSelected() ? EmmyWinArch.X64 : EmmyWinArch.X86;
             sb.append("package.cpath = package.cpath .. ';")


### PR DESCRIPTION
# 概述
有时，我们会发现在使用 IntelliJ-EmmyLua 来 Debug 时，一些字符串信息会显示不全。
具体的显示不全的情况有：字符串截断，ASCII控制字符被替换为固定字符，等等。
显示不全，导致调试过程中不方便，无法准确得知字符串的内容。

为了解决这个问题，本PR为 IntelliJ-EmmyLua 增加特性，可以使得 EmmyLua 在必要时增加显示字符串的Hex及ASCII码。

需要注意的是，本PR依赖EmmyLuaDebugger的PR，见[https://github.com/EmmyLua/EmmyLuaDebugger/pull/50](https://github.com/EmmyLua/EmmyLuaDebugger/pull/50)。

# 结合示例说明本PR

## 测试用例
假设正在断点调试以下代码：
```lua
local function hexToString(hexStr)
    return (hexStr:gsub('(%x%x)', function(h)
        local charNum = tonumber(h, 16)
        return string.char(charNum)
    end))
end
 
-- 常规的、可打印 单字节(ASCII) 字符串
local a = "abc"
-- 常规的、可打印的 单字节(ASCII) 及 三字节（中文） 字符串
local b = "a我c"
-- 不常规的本来不可直接打印的(如这里的0A,\n)
local c = hexToString("0A61E6889163")
-- 带终止符的字符串
local d = hexToString("6100E6889163")
-- 所有控制字符
local e = hexToString("610102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F7F63")
```

## 原版EmmyLua

当前最新官方版本：[1.4.9-IDEA231](https://plugins.jetbrains.com/plugin/9768-emmylua/versions/stable/437981)，发布日期：Nov 15, 2023，


断点，能看到以下内容：

![image](https://github.com/EmmyLua/IntelliJ-EmmyLua/assets/31504745/d9ed4de6-b3c6-488d-a4a0-87eca9c6c015)

分析：

- 观察c，我们知道，rider对0x0A(LF,换行符)进行了转义，能显示成\n。
- 观察d，lua底层是c，c遇到0x00(终止符)，就把后面的字节流忽略了。
- 观察e，这里能看到rider对哪些ASCII控制码有做转义，没有做转义的，特别地，7F(删除符)显示成了空格。

## 本PR版本

对同样的Lua代码进行断点，查看字符串的内容，有：

![image](https://github.com/EmmyLua/IntelliJ-EmmyLua/assets/31504745/4c6bbd6e-3cf9-4175-90fb-1da5200e084a)

![image](https://github.com/EmmyLua/IntelliJ-EmmyLua/assets/31504745/5500a1f8-cbc5-438e-9912-2a47ecd3b097)


分析：

- 观察a、b、c，与原版没有差异，因为原版已经把足够的信息表达出来了，所以我这里追加更多信息，避免干扰（平时开发过程中，遇到的大多数情况都属于这种常规情况）。
- 观察d、e，使用[Hex]、[ASCII]、[tostring]分割了三段字符串的表达形式：在[tostring]段，保留了原版的形式，；同时增加对应的Hex表示，以及ASCII表示。

# 实现细节

## 修改EmmyLuaDebug

核心修改为：[https://github.com/zhangjiequan/EmmyLuaDebugger/commit/38946d6df7b8ceb32e368715c0ada3c7bad419de](https://github.com/zhangjiequan/EmmyLuaDebugger/commit/38946d6df7b8ceb32e368715c0ada3c7bad419de)。

见EmmyLuaDebugger的PR：[https://github.com/EmmyLua/EmmyLuaDebugger/pull/50](https://github.com/EmmyLua/EmmyLuaDebugger/pull/50)。

主要是增加string类型，使得可以由后续的IntelliJ-EmmyLua中的emmyHelper.lua控制显示的内容。

## 修改IntelliJ-EmmyLua

核心修改为：[https://github.com/EmmyLua/IntelliJ-EmmyLua/commit/88fb70a79854c31480e1e5ff12bbaf986174d2ea](https://github.com/EmmyLua/IntelliJ-EmmyLua/commit/88fb70a79854c31480e1e5ff12bbaf986174d2ea)。


### 增加内容的条件
只在必要时，才去追加内容，避免不必要时追加了内容，造成干扰。

需要追加内容的条件是：
1. 是合法的utf8
2. 如果是utf8中的单字节，还需要符合rider下的可打印“isPrintable()”
（什么是可打印：根据实验，得到定义printableChars的字符是会被rider转义的，所以是可打印的；同时，按ascii规定，32~126的字符也是可打印的。）

### 输出模式
为了方便控制，我还提供了输出模式选项。

![image](https://github.com/EmmyLua/IntelliJ-EmmyLua/assets/31504745/3fb647fd-a81c-434b-bb60-b77d342ed76a)

1. Auto，自动，默认值，即判断如果当前字符串符合上面《增加内容的条件》的，就追加，否则不增加。
2. Concise，简洁，总是不增加。
3. Complete，完全，总是增加。

# 待办

## 插件面板中增加输出模式的选择

![image](https://github.com/EmmyLua/IntelliJ-EmmyLua/assets/31504745/423581ef-c880-460e-af83-235ebfb01bff)

类似架构选择，可以选择x64、x86，

这里增加对应的RadioButton，选择后会自动修改下方代码中的Mode。

需要修改的文件有：

1. IntelliJ-EmmyLua\src\main\java\com\tang\intellij\lua\debugger\emmy\EmmyDebugSettingsPanel.form
2. IntelliJ-EmmyLua\src\main\java\com\tang\intellij\lua\debugger\emmy\EmmyDebugSettingsPanel.java
3. IntelliJ-EmmyLua\src\main\java\com\tang\intellij\lua\debugger\emmy\EmmyDebugConfigurationType.kt
