### PR TITLE
External customization of the queryVariable method

### DIFF
--- a/src/main/resources/debugger/emmy/emmyHelper.lua
+++ b/src/main/resources/debugger/emmy/emmyHelper.lua
@@ -25,7 +25,10 @@ local emmy = {}
 local toluaHelper = {
     ---@param variable Variable
     queryVariable = function(variable, obj, typeName, depth)
-        if typeName == 'table' then
+        if emmyProject and emmyProject.extension and emmyProject.extension.queryVariable
+            and emmyProject.extension.queryVariable(variable, obj, typeName, depth) then
+            return true
+        elseif typeName == 'table' then
             local cname = rawget(obj, '__cname')
             if cname then
                 variable:query(obj, depth)
@@ -74,7 +77,10 @@ local toluaHelper = {
 
 local xluaDebugger = {
     queryVariable = function(variable, obj, typeName, depth)
-        if typeName == 'userdata' then
+        if emmyProject and emmyProject.extension and emmyProject.extension.queryVariable
+            and emmyProject.extension.queryVariable(variable, obj, typeName, depth) then
+            return true
+        elseif typeName == 'userdata' then
             local mt = getmetatable(obj)
             if mt == nil then
                 return false
@@ -141,7 +147,10 @@ local xluaDebugger = {
 
 local cocosLuaDebugger = {
     queryVariable = function(variable, obj, typeName, depth)
-        if typeName == 'userdata' then
+        if emmyProject and emmyProject.extension and emmyProject.extension.queryVariable
+            and emmyProject.extension.queryVariable(variable, obj, typeName, depth) then
+            return true
+        elseif typeName == 'userdata' then
             local mt = getmetatable(obj)
             if mt == nil then return false end
             variable.valueTypeName = 'C++'


### PR DESCRIPTION
用于自定义对所有lua类型的显示处理，以便项目侧自定义各种类型信息的可视化。
需要配合EmmyLuaDebugger的PR使用，见：[Extend queryHelper condition to include all lua types by zhangjiequan · Pull Request #51 · EmmyLua/EmmyLuaDebugger](https://github.com/EmmyLua/EmmyLuaDebugger/pull/51)。
项目侧使用方法，见：[Release IntelliJ-EmmyLua_1.4.9.9_external_queryvariable · zhangjiequan/IntelliJ-EmmyLua # Usage](https://github.com/zhangjiequan/IntelliJ-EmmyLua/releases/tag/1.4.9.9_external_queryvariable#:~:text=custom%20in%201.4.9.8.-,Usage,-package.cpath)。