### PR TITLE
修复第二次启动调试器可能无法hover查看正确的CS对象值

### DIFF
--- a/src/main/resources/debugger/emmy/emmyHelper.lua
+++ b/src/main/resources/debugger/emmy/emmyHelper.lua
@@ -187,12 +187,7 @@ elseif xlua then
     emmy = xluaDebugger
 end
 
-local emmyHelper = rawget(_G, "emmyHelper")
-if emmyHelper == nil then
-    rawset(_G, 'emmyHelper', emmy)
-elseif emmy.queryVariable then
-    emmyHelper.queryVariable = emmy.queryVariable
-end
+rawset(_G, 'emmyHelper', emmy)
 
 local emmyHelperInit = rawget(_G, 'emmyHelperInit')
 if emmyHelperInit then


### PR DESCRIPTION
第二次执行emmyHelper这个文件的时候，emmyHelper这个全局变量已经存在了，就不会把emmy赋值给emmyHelper。emmyHelperInit只会把createNode函数添加到emmyHelper不会添加到emmy上，所以第二次启动调试器无法找到emmy.createNode函数导致Bug。