### PR TITLE
Supports standard options: LINE_COMMENT_ADD_SPACE/LINE_COMMENT_AT_FIRST_COLUMN

### DIFF
--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
@@ -75,6 +75,12 @@ class LuaLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
                         "Align table field assign",
                         "Table")
             }
+            SettingsType.COMMENTER_SETTINGS -> {
+                consumer.showStandardOptions(
+                    "LINE_COMMENT_ADD_SPACE",
+                    "LINE_COMMENT_AT_FIRST_COLUMN"
+                )
+            }
             else -> {
             }
         }


### PR DESCRIPTION
Supports standard options: LINE_COMMENT_ADD_SPACE/LINE_COMMENT_AT_FIRST_COLUMN
Although it cannot be configured in CodeStyle, it can be configured in the .editorconfig file:
[*.lua]
ij_lua_line_comment_add_space = true
ij_lua_line_comment_at_first_column = false