### PR TITLE
Supports standard options: LINE_COMMENT_ADD_SPACE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build Plugin
 
 on:
-  push:
-    branches:
-      - '*'
+  workflow_dispatch:
+#  push:
+#    branches:
+#      - '*'
 #  pull_request:
 #    branches: [ "master" ]
 

--- a/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
+++ b/src/main/java/com/tang/intellij/lua/editor/formatter/LuaLanguageCodeStyleSettingsProvider.kt
@@ -75,6 +75,9 @@ class LuaLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
                         "Align table field assign",
                         "Table")
             }
+            SettingsType.COMMENTER_SETTINGS -> {
+                consumer.showStandardOptions("LINE_COMMENT_ADD_SPACE")
+            }
             else -> {
             }
         }


### PR DESCRIPTION
Supports standard options: LINE_COMMENT_ADD_SPACE
Although it cannot be configured in CodeStyle, it can be configured in the .editorconfig file:
[*.lua]
ij_lua_line_comment_add_space = true